### PR TITLE
ForTrilinos: update docker mount options to deal with SELINUX on Fedora

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   fortrilinos_dev:
     image: aprokop/fortrilinos-stack:latest
     volumes:
-      - ..:/scratch/source/trilinos/release/packages/ForTrilinos
+      - ..:/scratch/source/trilinos/release/packages/ForTrilinos:rw,z
     environment:
       - TERM=xterm
     # Append user name to the container name.  Specifying a container name


### PR DESCRIPTION
The main thing: add `-z`.