### PR TITLE
Fix MPI_Comm treatment in simple interface

### DIFF
--- a/src/simple/src/fortrilinos.i
+++ b/src/simple/src/fortrilinos.i
@@ -5,6 +5,7 @@
 
 %include "ForTrilinosSimpleInterface_config.hpp"
 
+// Mpi_Comm typemaps
 %typemap(in, noblock=1) MPI_Comm %{
 #ifdef HAVE_MPI
     $1 = ($1_ltype)(MPI_Comm_f2c(*(MPI_Fint *)($input)));
@@ -12,6 +13,9 @@
     $1 = *$input;
 #endif
 %}
+%typemap(ftype)  MPI_Comm %{integer(C_INT), intent(in)%}
+%typemap(imtype) MPI_Comm %{integer(C_INT), intent(in)%}
+%typemap(fin)    MPI_Comm %{$1_name%}
 
 // Generate wrappers
 %include "trilinos_handle.i"

--- a/src/simple/src/fortrilinosFORTRAN_wrap.cxx
+++ b/src/simple/src/fortrilinosFORTRAN_wrap.cxx
@@ -268,7 +268,7 @@ SWIGEXPORT void swigc_TrilinosHandle_init__SWIG_0(void* farg1) {
 }
 
 
-SWIGEXPORT void swigc_TrilinosHandle_init__SWIG_1(void* farg1, int* farg2) {
+SWIGEXPORT void swigc_TrilinosHandle_init__SWIG_1(void* farg1, void* farg2) {
   ForTrilinos::TrilinosHandle *arg1 = (ForTrilinos::TrilinosHandle *) 0 ;
   MPI_Comm arg2 ;
   


### PR DESCRIPTION
PR #47 was pushed even though I now discovered it did not treat MPI_Comm
right resulting in uknown types in .f90 files due to missing typemaps.
This patch fixes the issue.