### PR TITLE
[WIP] Update to testing macros and TpetraMultiVector tests added

### DIFF
--- a/src/tpetra/test/CMakeLists.txt
+++ b/src/tpetra/test/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 SET(TESTS
   test_tpetra_map.f90
+  test_tpetra_multivector.f90
   )
 
 FOREACH(test ${TESTS})

--- a/src/tpetra/test/test_tpetra_map.f90
+++ b/src/tpetra/test/test_tpetra_map.f90
@@ -8,6 +8,8 @@ program test_TpetraMap
 
   DECLARE_TEST_VARIABLES()
   type(TeuchosComm) :: comm
+  integer(global_size_type), parameter :: invalid=-1
+  integer(global_ordinal_type), parameter :: index_base=1
 
   INITIALIZE_TEST()
 
@@ -19,31 +21,33 @@ program test_TpetraMap
   CHECK_IERR()
 #endif
 
-  ADD_SUBTEST_AND_RUN(test_isOneToOne)
-  ADD_SUBTEST_AND_RUN(test_getGlobalNumElements)
-  ADD_SUBTEST_AND_RUN(test_getNodeNumElements)
-  ADD_SUBTEST_AND_RUN(test_getIndexBase)
-  ADD_SUBTEST_AND_RUN(test_getMinLocalIndex)
-  ADD_SUBTEST_AND_RUN(test_getMaxLocalIndex)
-  ADD_SUBTEST_AND_RUN(test_getMinGlobalIndex)
-  ADD_SUBTEST_AND_RUN(test_getMaxGlobalIndex)
-  ADD_SUBTEST_AND_RUN(test_getMinAllGlobalIndex)
-  ADD_SUBTEST_AND_RUN(test_getMaxAllGlobalIndex)
-  ADD_SUBTEST_AND_RUN(test_getLocalElement)
-  ADD_SUBTEST_AND_RUN(test_getGlobalElement)
-  ADD_SUBTEST_AND_RUN(test_getNodeElementList)
-  ADD_SUBTEST_AND_RUN(test_isNodeLocalElement)
-  ADD_SUBTEST_AND_RUN(test_isNodeGlobalElement)
-  ADD_SUBTEST_AND_RUN(test_isUniform)
-  ADD_SUBTEST_AND_RUN(test_isContiguous)
-  ADD_SUBTEST_AND_RUN(test_isDistributed)
-  ADD_SUBTEST_AND_RUN(test_isCompatible)
-  ADD_SUBTEST_AND_RUN(test_isSameAs)
-  ADD_SUBTEST_AND_RUN(test_locallySameAs)
-  ADD_SUBTEST_AND_RUN(test_getComm)
-  ADD_SUBTEST_AND_RUN(test_description)
-  ADD_SUBTEST_AND_RUN(test_removeEmptyProcesses)
-  ADD_SUBTEST_AND_RUN(test_replaceCommWithSubset)
+  ADD_SUBTEST_AND_RUN(TpetraMap_isOneToOne)
+  ADD_SUBTEST_AND_RUN(TpetraMap_getGlobalNumElements)
+  ADD_SUBTEST_AND_RUN(TpetraMap_getNodeNumElements)
+  ADD_SUBTEST_AND_RUN(TpetraMap_getIndexBase)
+  ADD_SUBTEST_AND_RUN(TpetraMap_getMinLocalIndex)
+  ADD_SUBTEST_AND_RUN(TpetraMap_getMaxLocalIndex)
+  ADD_SUBTEST_AND_RUN(TpetraMap_getMinGlobalIndex)
+  ADD_SUBTEST_AND_RUN(TpetraMap_getMaxGlobalIndex)
+  ADD_SUBTEST_AND_RUN(TpetraMap_getMinAllGlobalIndex)
+  ADD_SUBTEST_AND_RUN(TpetraMap_getMaxAllGlobalIndex)
+  ADD_SUBTEST_AND_RUN(TpetraMap_getLocalElement)
+  ADD_SUBTEST_AND_RUN(TpetraMap_getGlobalElement)
+  ADD_SUBTEST_AND_RUN(TpetraMap_getNodeElementList)
+  ADD_SUBTEST_AND_RUN(TpetraMap_isNodeLocalElement)
+  ADD_SUBTEST_AND_RUN(TpetraMap_isNodeGlobalElement)
+  ADD_SUBTEST_AND_RUN(TpetraMap_isUniform)
+  ADD_SUBTEST_AND_RUN(TpetraMap_isContiguous)
+  ADD_SUBTEST_AND_RUN(TpetraMap_isDistributed)
+  ADD_SUBTEST_AND_RUN(TpetraMap_isCompatible)
+  ADD_SUBTEST_AND_RUN(TpetraMap_isSameAs)
+  ADD_SUBTEST_AND_RUN(TpetraMap_locallySameAs)
+  ADD_SUBTEST_AND_RUN(TpetraMap_getComm)
+  ADD_SUBTEST_AND_RUN(TpetraMap_description)
+
+  ! Methods listed below are marked as "may go away or change at any time"
+  ADD_SUBTEST_AND_RUN(TpetraMap_removeEmptyProcesses)
+  ADD_SUBTEST_AND_RUN(TpetraMap_replaceCommWithSubset)
 
   call comm%release()
   CHECK_IERR()
@@ -53,87 +57,78 @@ program test_TpetraMap
 contains
 
 ! ---------------------------------isOneToOne--------------------------------- !
-  integer function test_isOneToOne()
+  FORTRILINOS_UNIT_TEST(TpetraMap_isOneToOne)
     integer :: jerr
     logical(c_bool) :: bool
     type(TpetraMap) :: Obj
-    integer(global_ordinal_type) :: num_global, index_base, indices(4)
+    integer(global_ordinal_type) :: num_global, indices(4)
     jerr = 0
-    index_base = 1
     num_global = 4*comm%getSize()
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_isOneToOne)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
-    bool = Obj%isOneToOne(); TEST_FOR_IERR(test_isOneToOne)
+    bool = Obj%isOneToOne(); TEST_IERR()
     if (.not. bool) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "isOneToOne: Expected map to be one to one"
     end if
 
-    call Obj%release(); TEST_FOR_IERR(test_isOneToOne)
+    call Obj%release(); TEST_IERR()
 
     if (comm%getSize() > 1) then
       indices = [1, 2, 3, 4]
-      call Obj%create(num_global, indices, index_base, comm)
-      TEST_FOR_IERR(test_isOneToOne)
+      call Obj%create(num_global, indices, index_base, comm); TEST_IERR()
 
-      bool = Obj%isOneToOne(); TEST_FOR_IERR(test_isOneToOne)
+      bool = Obj%isOneToOne(); TEST_IERR()
       if (bool) then
         jerr = jerr + 1
         if (comm%getRank() == 0) &
           write(*,*) "isOneToOne: Expected map to NOT be one to one"
       end if
 
-      call Obj%release(); TEST_FOR_IERR(test_isOneToOne)
+      call Obj%release(); TEST_IERR()
 
     end if
 
-    SET_ERROR_COUNT_AND_RETURN(test_isOneToOne, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_isOneToOne)
 
 ! ----------------------------getGlobalNumElements---------------------------- !
-  integer function test_getGlobalNumElements()
+  FORTRILINOS_UNIT_TEST(TpetraMap_getGlobalNumElements)
     integer :: jerr
     type(TpetraMap) :: Obj
     integer(C_LONG) :: fresult
-    integer(global_ordinal_type) :: num_global, index_base
+    integer(global_ordinal_type) :: num_global
     jerr = 0
-    index_base = 1
     num_global = 4*comm%getSize()
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_getGlobalNumElements)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
-    fresult = Obj%getGlobalNumElements()
-    TEST_FOR_IERR(test_getGlobalNumElements)
+    fresult = Obj%getGlobalNumElements(); TEST_IERR()
     if (fresult /= num_global) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "getGlobalNumElements: Expected ", num_global, " elements, got ", fresult
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_getGlobalNumElements)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_getGlobalNumElements, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_getGlobalNumElements)
 
 ! -----------------------------getNodeNumElements----------------------------- !
-  integer function test_getNodeNumElements()
+  FORTRILINOS_UNIT_TEST(TpetraMap_getNodeNumElements)
     integer :: jerr
     type(TpetraMap) :: Obj
     integer(C_SIZE_T) :: fresult
-    integer(global_ordinal_type) :: num_global, index_base
+    integer(global_ordinal_type) :: num_global
     jerr = 0
-    index_base = 1
     num_global = 4*comm%getSize()
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_getNodeNumElements)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
     fresult = Obj%getNodeNumElements()
     if (fresult /= 4) then
@@ -142,155 +137,132 @@ contains
         write(*,*) "getNodeNumElements: Expected ", 4, " elements, got ", fresult
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_getNodeNumElements)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_getNodeNumElements, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_getNodeNumElements)
 
 ! --------------------------------getIndexBase-------------------------------- !
-  integer function test_getIndexBase()
+  FORTRILINOS_UNIT_TEST(TpetraMap_getIndexBase)
     integer :: jerr
     type(TpetraMap) :: Obj
     integer(C_LONG_LONG) :: fresult
-    integer(global_ordinal_type) :: num_global, index_base
+    integer(global_ordinal_type) :: num_global, index_base_0
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_getIndexBase)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
-    fresult = Obj%getIndexBase()
-    TEST_FOR_IERR(test_getIndexBase)
+    fresult = Obj%getIndexBase(); TEST_IERR()
     if (fresult /= 1) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "getIndexBase: Expected indexBase = ", 1, " got ", fresult
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_getIndexBase)
+    call Obj%release(); TEST_IERR()
 
-    index_base = 0
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_getIndexBase)
+    index_base_0 = 0
+    call Obj%create(num_global, index_base_0, comm); TEST_IERR()
 
-    fresult = Obj%getIndexBase()
-    TEST_FOR_IERR(test_getIndexBase)
+    fresult = Obj%getIndexBase(); TEST_IERR()
     if (fresult /= 0) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "getIndexBase: Expected indexBase = ", 0, " got ", fresult
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_getIndexBase)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_getIndexBase, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_getIndexBase)
 
 ! ------------------------------getMinLocalIndex------------------------------ !
-  integer function test_getMinLocalIndex()
+  FORTRILINOS_UNIT_TEST(TpetraMap_getMinLocalIndex)
     integer :: jerr
     type(TpetraMap) :: Obj
     integer(C_INT) :: fresult
-    integer(global_ordinal_type) :: num_global, index_base
+    integer(global_ordinal_type) :: num_global
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_getMinLocalIndex)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
-    fresult = Obj%getMinLocalIndex()
-    TEST_FOR_IERR(test_getMinLocalIndex)
+    fresult = Obj%getMinLocalIndex(); TEST_IERR()
     if (fresult /= 1) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "getMinLocalIndex: Expected minLocalIndex = ", 1, " got ", fresult
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_getMinLocalIndex)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_getMinLocalIndex, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_getMinLocalIndex)
 
 ! ------------------------------getMaxLocalIndex------------------------------ !
-  integer function test_getMaxLocalIndex()
+  FORTRILINOS_UNIT_TEST(TpetraMap_getMaxLocalIndex)
     integer :: jerr
     type(TpetraMap) :: Obj
     integer(C_INT) :: fresult
-    integer(global_ordinal_type) :: num_global, index_base
+    integer(global_ordinal_type) :: num_global
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_getMaxLocalIndex)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
-    fresult = Obj%getMaxLocalIndex()
-    TEST_FOR_IERR(test_getMaxLocalIndex)
+    fresult = Obj%getMaxLocalIndex(); TEST_IERR()
     if (fresult /= 4) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "getMaxLocalIndex: Expected maxLocalIndex = ", 4, " got ", fresult
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_getMaxLocalIndex)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_getMaxLocalIndex, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_getMaxLocalIndex)
 
 ! -----------------------------getMinGlobalIndex------------------------------ !
-  integer function test_getMinGlobalIndex()
+  FORTRILINOS_UNIT_TEST(TpetraMap_getMinGlobalIndex)
     integer :: jerr
     type(TpetraMap) :: Obj
     integer(C_LONG_LONG) :: fresult, expected
-    integer(global_ordinal_type) :: num_global, index_base
+    integer(global_ordinal_type) :: num_global
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_getMinGlobalIndex)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
-    fresult = Obj%getMinGlobalIndex()
-    TEST_FOR_IERR(test_getMinGlobalIndex)
+    fresult = Obj%getMinGlobalIndex(); TEST_IERR()
     expected = comm%getRank() * 4 + 1
     if (fresult /= expected) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "getMindGlobalIndex: Expected minGlobalIndex = ", expected, " got ", fresult
     end if
-    call Obj%release()
-    TEST_FOR_IERR(test_getMinGlobalIndex)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_getMinGlobalIndex, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_getMinGlobalIndex)
 
 ! -----------------------------getMaxGlobalIndex------------------------------ !
-  integer function test_getMaxGlobalIndex()
+  FORTRILINOS_UNIT_TEST(TpetraMap_getMaxGlobalIndex)
     integer :: jerr
     type(TpetraMap) :: Obj
     integer(C_LONG_LONG) :: fresult, expected
-    integer(global_ordinal_type) :: num_global, index_base
+    integer(global_ordinal_type) :: num_global
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_getMaxGlobalIndex)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
-    fresult = Obj%getMaxGlobalIndex()
-    TEST_FOR_IERR(test_getMaxGlobalIndex)
+    fresult = Obj%getMaxGlobalIndex(); TEST_IERR()
     expected = comm%getRank() * 4 + 4
     if (fresult /= expected) then
       jerr = jerr + 1
@@ -298,86 +270,74 @@ contains
         write(*,*) "getMaxGlobalIndex: Expected maxGloblIndex = ", expected, " got ", fresult
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_getMaxGlobalIndex)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_getMaxGlobalIndex, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_getMaxGlobalIndex)
 
 ! ----------------------------getMinAllGlobalIndex---------------------------- !
-  integer function test_getMinAllGlobalIndex()
+  FORTRILINOS_UNIT_TEST(TpetraMap_getMinAllGlobalIndex)
     integer :: jerr
     type(TpetraMap) :: Obj
     integer(C_LONG_LONG) :: fresult
-    integer(global_ordinal_type) :: num_global, index_base
+    integer(global_ordinal_type) :: num_global
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_getMinAllGlobalIndex)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
-    fresult = Obj%getMinAllGlobalIndex()
-    TEST_FOR_IERR(test_getMinAllGlobalIndex)
+    fresult = Obj%getMinAllGlobalIndex(); TEST_IERR()
     if (fresult /= index_base) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "getMinAllGlobalIndex: Expected minAllGlobalIndex = ", index_base, " got ", fresult
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_getMinAllGlobalIndex)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_getMinAllGlobalIndex, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_getMinAllGlobalIndex)
 
 ! ----------------------------getMaxAllGlobalIndex---------------------------- !
-  integer function test_getMaxAllGlobalIndex()
+  FORTRILINOS_UNIT_TEST(TpetraMap_getMaxAllGlobalIndex)
     integer :: jerr
     type(TpetraMap) :: Obj
     integer(C_LONG_LONG) :: fresult
-    integer(global_ordinal_type) :: num_global, index_base
+    integer(global_ordinal_type) :: num_global
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_getMaxAllGlobalIndex)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
-    fresult = Obj%getMaxAllGlobalIndex()
-    TEST_FOR_IERR(test_getMaxAllGlobalIndex)
+    fresult = Obj%getMaxAllGlobalIndex(); TEST_IERR()
     if (fresult /= num_global) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "getMaxAllGlobalIndex: Expected maxAllGlobalIndex = ", num_global, " got ", fresult
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_getMaxAllGlobalIndex)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_getMaxAllGlobalIndex, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_getMaxAllGlobalIndex)
 
 ! ------------------------------getLocalElement------------------------------- !
-  integer function test_getLocalElement()
+  FORTRILINOS_UNIT_TEST(TpetraMap_getLocalElement)
     integer :: jerr
     type(TpetraMap) :: Obj
     integer(C_LONG_LONG) :: globalindex
     integer(C_INT) :: fresult
-    integer(global_ordinal_type) :: num_global, index_base
+    integer(global_ordinal_type) :: num_global
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_getLocalElement)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
     globalindex = comm%getRank() * 4 + 1
-    fresult = Obj%getLocalElement(globalindex)
-    TEST_FOR_IERR(test_getLocalElement)
+    fresult = Obj%getLocalElement(globalindex); TEST_IERR()
     if (fresult /= 1) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
@@ -385,39 +345,34 @@ contains
     end if
 
     globalindex = comm%getRank() * 4 + 4
-    fresult = Obj%getLocalElement(globalindex)
-    TEST_FOR_IERR(test_getLocalElement)
+    fresult = Obj%getLocalElement(globalindex); TEST_IERR()
     if (fresult /= 4) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "getLocalElement: Expected local element = ", 4, " got ", fresult
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_getLocalElement)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_getLocalElement, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_getLocalElement)
 
 ! ------------------------------getGlobalElement------------------------------ !
-  integer function test_getGlobalElement()
+  FORTRILINOS_UNIT_TEST(TpetraMap_getGlobalElement)
     integer :: jerr
     type(TpetraMap) :: Obj
     integer(C_INT) :: localindex
     integer(C_LONG_LONG) :: fresult, expected
-    integer(global_ordinal_type) :: num_global, index_base
+    integer(global_ordinal_type) :: num_global
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_getGlobalElement)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
     localindex = 1
     expected = comm%getRank() * 4 + 1
-    fresult = Obj%getGlobalElement(localindex)
-    TEST_FOR_IERR(test_getGlobalElement)
+    fresult = Obj%getGlobalElement(localindex); TEST_IERR()
     if (fresult /= expected) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
@@ -426,70 +381,47 @@ contains
 
     localindex = 4
     expected = comm%getRank() * 4 + 4
-    fresult = Obj%getGlobalElement(localindex)
-    TEST_FOR_IERR(test_getGlobalElement)
+    fresult = Obj%getGlobalElement(localindex); TEST_IERR()
     if (fresult /= expected) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "getGlobalElement: Expected global element = ", expected, " got ", fresult
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_getGlobalElement)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_getGlobalElement, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_getGlobalElement)
 
 ! -----------------------------getNodeElementList----------------------------- !
-  integer function test_getNodeElementList()
-    integer :: jerr
+  FORTRILINOS_UNIT_TEST(TpetraMap_getNodeElementList)
     type(TpetraMap) :: Obj
-    type(TeuchosArrayViewLongLongConst) :: fresult
-    integer(global_ordinal_type) :: num_global, index_base
-    jerr = 0
+    integer(global_ordinal_type), allocatable :: element_list(:)
+    integer(global_ordinal_type) :: num_global
     num_global = 4*comm%getSize()
-    index_base = 1
-
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_getNodeElementList)
-
-    fresult = Obj%getNodeElementList()
-    TEST_FOR_IERR(test_getNodeElementList)
-
-    ! TODO: getNodeElementList should be modified to be a subroutine that takes
-    ! TODO: the element list as a return argument.  Otherwise, there is no
-    ! TODO: (current) way to get to the data in the ArrayView returned.
-    if (comm%getRank() == 0) &
-      write(*,*) "getNodeElementList: Test not yet implemented"
-
-    call fresult%release()
-    TEST_FOR_IERR(test_getNodeElementList)
-
-    call Obj%release()
-    TEST_FOR_IERR(test_getNodeElementList)
-
-    SET_ERROR_COUNT_AND_RETURN(test_getNodeElementList, jerr)
-
-  end function
+    allocate(element_list(4))
+    ! TODO: The element list returned is junk
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
+    call Obj%getNodeElementList(element_list)
+    deallocate(element_list)
+    call Obj%release(); TEST_IERR()
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_getNodeElementList)
 
 ! -----------------------------isNodeLocalElement----------------------------- !
-  integer function test_isNodeLocalElement()
+  FORTRILINOS_UNIT_TEST(TpetraMap_isNodeLocalElement)
     integer :: jerr
     type(TpetraMap) :: Obj
     integer(C_INT) :: localindex
     logical(C_BOOL) :: fresult
-    integer(global_ordinal_type) :: num_global, index_base
+    integer(global_ordinal_type) :: num_global
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_isNodeLocalElement)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
     localindex = 1
-    fresult = Obj%isNodeLocalElement(localindex)
-    TEST_FOR_IERR(test_isNodeLocalElement)
+    fresult = Obj%isNodeLocalElement(localindex); TEST_IERR()
     if (.not. fresult) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
@@ -497,38 +429,33 @@ contains
     end if
 
     localindex = 5
-    fresult = Obj%isNodeLocalElement(localindex)
-    TEST_FOR_IERR(test_isNodeLocalElement)
+    fresult = Obj%isNodeLocalElement(localindex); TEST_IERR()
     if (fresult) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "isNodeLocalElement: expected 5 to NOT be a local index"
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_isNodeLocalElement)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_isNodeLocalElement, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_isNodeLocalElement)
 
 ! ----------------------------isNodeGlobalElement----------------------------- !
-  integer function test_isNodeGlobalElement()
+  FORTRILINOS_UNIT_TEST(TpetraMap_isNodeGlobalElement)
     integer :: jerr
     type(TpetraMap) :: Obj
     integer(C_LONG_LONG) :: globalindex
     logical(C_BOOL) :: fresult
-    integer(global_ordinal_type) :: num_global, index_base
+    integer(global_ordinal_type) :: num_global
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_isNodeGlobalElement)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
     globalindex = int(comm%getRank() * 4 + 1, kind=global_ordinal_type)
-    fresult = Obj%isNodeGlobalElement(globalindex)
-    TEST_FOR_IERR(test_isNodeGlobalElement)
+    fresult = Obj%isNodeGlobalElement(globalindex); TEST_IERR()
     if (.not. fresult) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
@@ -536,128 +463,109 @@ contains
     end if
     globalindex = num_global + 1
 
-    fresult = Obj%isNodeGlobalElement(globalindex)
-    TEST_FOR_IERR(test_isNodeGlobalElement)
+    fresult = Obj%isNodeGlobalElement(globalindex); TEST_IERR()
     if (fresult) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "isNodeGlobalElement: expected 5 to NOT be a global index"
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_isNodeGlobalElement)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_isNodeGlobalElement, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_isNodeGlobalElement)
 
 ! ---------------------------------isUniform---------------------------------- !
-  integer function test_isUniform()
+  FORTRILINOS_UNIT_TEST(TpetraMap_isUniform)
     integer :: jerr
     type(TpetraMap) :: Obj
     logical(C_BOOL) :: fresult
     integer :: k
-    integer(global_ordinal_type) :: num_global, index_base, elements(4)
+    integer(global_ordinal_type) :: num_global, elements(4)
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_isUniform)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
-    fresult = Obj%isUniform()
-    TEST_FOR_IERR(test_isUniform)
+    fresult = Obj%isUniform(); TEST_IERR()
     if (.not. fresult) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "isUniform: expected map to be uniform"
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_isUniform)
+    call Obj%release(); TEST_IERR()
 
     do k = 1, 4
       elements(k) = int(comm%getRank()+k*comm%getSize(), kind=global_ordinal_type)
     end do
-    call Obj%create(num_global, elements, index_base, comm);
-    TEST_FOR_IERR(test_isUniform)
+    call Obj%create(num_global, elements, index_base, comm); TEST_IERR()
 
-    fresult = Obj%isUniform()
-    TEST_FOR_IERR(test_isUniform)
+    fresult = Obj%isUniform(); TEST_IERR()
     if (fresult) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "isUniform: expected map to NOT be uniform"
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_isUniform)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_isUniform, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_isUniform)
 
 ! --------------------------------isContiguous-------------------------------- !
-  integer function test_isContiguous()
+  FORTRILINOS_UNIT_TEST(TpetraMap_isContiguous)
     integer :: jerr
     type(TpetraMap) :: Obj
     logical(C_BOOL) :: fresult
     integer :: k
-    integer(global_ordinal_type) :: num_global, index_base, elements(4)
+    integer(global_ordinal_type) :: num_global, elements(4)
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_isContiguous)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
-    fresult = Obj%isContiguous()
-    TEST_FOR_IERR(test_isContiguous)
+    fresult = Obj%isContiguous(); TEST_IERR()
     if (.not. fresult) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "isContiguous: expected map to be uniform"
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_isContiguous)
+    call Obj%release(); TEST_IERR()
 
     do k = 1, 4
       elements(k) = int(comm%getRank()+k*comm%getSize(), kind=global_ordinal_type)
     end do
-    call Obj%create(num_global, elements, index_base, comm);
-    TEST_FOR_IERR(test_isContiguous)
+    call Obj%create(num_global, elements, index_base, comm); TEST_IERR()
 
-    fresult = Obj%isContiguous()
-    TEST_FOR_IERR(test_isContiguous)
+    fresult = Obj%isContiguous(); TEST_IERR()
     if (fresult) then
       jerr = jerr + 1
       if (comm%getRank() == 0) &
         write(*,*) "isContiguous: expected map to NOT be uniform"
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_isContiguous)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_isContiguous, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_isContiguous)
 
 ! -------------------------------isDistributed-------------------------------- !
-  integer function test_isDistributed()
+  FORTRILINOS_UNIT_TEST(TpetraMap_isDistributed)
     integer :: jerr
     type(TpetraMap) :: Obj
     logical(C_BOOL) :: fresult
-    integer(global_ordinal_type) :: num_global, index_base, elements(4)
+    integer(global_ordinal_type) :: num_global, elements(4)
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_isDistributed)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
-    fresult = Obj%isDistributed()
-    TEST_FOR_IERR(test_isDistributed)
+    fresult = Obj%isDistributed(); TEST_IERR()
     if (comm%getSize() == 1) then
 
       if (fresult) then
@@ -676,18 +584,15 @@ contains
 
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_isDistributed)
+    call Obj%release(); TEST_IERR()
 
     ! All elements have 4 entries and map has only 4 entries so the map should
     ! not be distributed
     num_global = 4
     elements = [1, 2, 3, 4]
-    call Obj%create(num_global, elements, index_base, comm)
-    TEST_FOR_IERR(test_isDistributed)
+    call Obj%create(num_global, elements, index_base, comm); TEST_IERR()
 
-    fresult = Obj%isDistributed()
-    TEST_FOR_IERR(test_isDistributed)
+    fresult = Obj%isDistributed(); TEST_IERR()
     if (comm%getSize() == 1) then
 
       if (fresult) then
@@ -706,206 +611,170 @@ contains
 
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_isDistributed)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_isDistributed, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_isDistributed)
 
 ! --------------------------------isCompatible-------------------------------- !
-  integer function test_isCompatible()
+  FORTRILINOS_UNIT_TEST(TpetraMap_isCompatible)
     integer :: jerr
     type(TpetraMap) :: Obj1, Obj2
     type(TpetraMap) :: map
     logical(C_BOOL) :: fresult
-    integer(global_ordinal_type) :: num_global, index_base, elements(4)
+    integer(global_ordinal_type) :: num_global, elements(4)
     integer :: k
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj1%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_isCompatible)
+    call Obj1%create(num_global, index_base, comm); TEST_IERR()
 
     do k = 1, 4
       elements(k) = int(comm%getRank()+k*comm%getSize(), kind=global_ordinal_type)
     end do
-    call Obj2%create(num_global, elements, index_base, comm);
-    TEST_FOR_IERR(test_isCompatible)
+    call Obj2%create(num_global, elements, index_base, comm); TEST_IERR()
 
     ! Cyclic map should be compatible
-    fresult = Obj1%isCompatible(Obj2)
-    TEST_FOR_IERR(test_isCompatible)
+    fresult = Obj1%isCompatible(Obj2); TEST_IERR()
     if (.not. fresult) then
         jerr = jerr + 1
         if (comm%getRank()==0) &
           write(*,*) "isCompatible: Expected maps to be compatible"
     end if
 
-    call Obj2%release()
-    TEST_FOR_IERR(test_isCompatible)
+    call Obj2%release(); TEST_IERR()
 
     num_global = num_global + 10
-    call Obj2%create(num_global, index_base, comm);
-    TEST_FOR_IERR(test_isCompatible)
+    call Obj2%create(num_global, index_base, comm); TEST_IERR()
 
-    fresult = Obj1%isCompatible(Obj2)
-    TEST_FOR_IERR(test_isCompatible)
+    fresult = Obj1%isCompatible(Obj2); TEST_IERR()
     if (fresult) then
       jerr = jerr + 1
       if (comm%getRank()==0) &
         write(*,*) "isCompatible: Expected maps to NOT be compatible"
     end if
 
-    call Obj2%release()
-    TEST_FOR_IERR(test_isCompatible)
+    call Obj2%release(); TEST_IERR()
+    call Obj1%release(); TEST_IERR()
 
-    call Obj1%release()
-    TEST_FOR_IERR(test_isCompatible)
+    success = (jerr == 0)
 
-    SET_ERROR_COUNT_AND_RETURN(test_isCompatible, jerr)
-
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_isCompatible)
 
 ! ----------------------------------isSameAs---------------------------------- !
-  integer function test_isSameAs()
+  FORTRILINOS_UNIT_TEST(TpetraMap_isSameAs)
     integer :: jerr
     type(TpetraMap) :: Obj1, Obj2
     type(TpetraMap) :: map
     logical(C_BOOL) :: fresult
     integer(size_type) :: num_local
-    integer(global_ordinal_type) :: num_global, index_base, elements(4)
-    integer(global_size_type) :: invalid
+    integer(global_ordinal_type) :: num_global, elements(4)
     integer :: k
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj1%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_isSameAs)
+    call Obj1%create(num_global, index_base, comm); TEST_IERR()
 
     if (comm%getSize() > 1) then
 
       do k = 1, 4
         elements(k) = int(comm%getRank()+k*comm%getSize(), kind=global_ordinal_type)
       end do
-      call Obj2%create(num_global, elements, index_base, comm);
-      TEST_FOR_IERR(test_isSameAs)
+      call Obj2%create(num_global, elements, index_base, comm); TEST_IERR()
 
       ! Cyclic map should not be SameAs
-      fresult = Obj1%isSameAs(Obj2)
-      TEST_FOR_IERR(test_isSameAs)
+      fresult = Obj1%isSameAs(Obj2); TEST_IERR()
       if (fresult) then
         jerr = jerr + 1
         if (comm%getRank()==0) &
           write(*,*) "isSameAs: Expected maps to NOT be same"
       end if
 
-      call Obj2%release()
-      TEST_FOR_IERR(test_isSameAs)
+      call Obj2%release(); TEST_IERR()
 
     end if
 
-    invalid = -1; num_local = 4
-    call Obj2%create(invalid, num_local, index_base, comm)
-    TEST_FOR_IERR(test_isSameAs)
+    num_local = 4
+    call Obj2%create(invalid, num_local, index_base, comm); TEST_IERR()
 
-    fresult = Obj1%isSameAs(Obj2)
-    TEST_FOR_IERR(test_isSameAs)
+    fresult = Obj1%isSameAs(Obj2); TEST_IERR()
     if (.not. fresult) then
       jerr = jerr + 1
       if (comm%getRank()==0) &
         write(*,*) "isSameAs: Expected maps to be same"
     end if
 
-    call Obj1%release()
-    TEST_FOR_IERR(test_isSameAs)
+    call Obj1%release(); TEST_IERR()
+    call Obj2%release(); TEST_IERR()
 
-    call Obj2%release()
-    TEST_FOR_IERR(test_isSameAs)
+    success = (jerr == 0)
 
-    SET_ERROR_COUNT_AND_RETURN(test_isSameAs, jerr)
-
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_isSameAs)
 
 ! -------------------------------locallySameAs-------------------------------- !
-  integer function test_locallySameAs()
+  FORTRILINOS_UNIT_TEST(TpetraMap_locallySameAs)
     integer :: jerr
     type(TpetraMap) :: Obj1, Obj2
     logical(C_BOOL) :: fresult
     integer(size_type) :: num_local
-    integer(global_ordinal_type) :: num_global, index_base, elements(4)
-    integer(global_size_type) :: invalid
+    integer(global_ordinal_type) :: num_global, elements(4)
     integer :: k
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj1%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_locallySameAs)
+    call Obj1%create(num_global, index_base, comm); TEST_IERR()
 
     if (comm%getSize() > 1) then
 
       do k = 1, 4
         elements(k) = int(comm%getRank()+k*comm%getSize(), kind=global_ordinal_type)
       end do
-      call Obj2%create(num_global, elements, index_base, comm);
-      TEST_FOR_IERR(test_locallySameAs)
+      call Obj2%create(num_global, elements, index_base, comm); TEST_IERR()
 
       ! Cyclic map should not be locallySameAs
-      fresult = Obj1%locallySameAs(Obj2)
-      TEST_FOR_IERR(test_locallySameAs)
+      fresult = Obj1%locallySameAs(Obj2); TEST_IERR()
       if (fresult) then
         jerr = jerr + 1
         if (comm%getRank()==0) &
           write(*,*) "locallySameAs: Expected maps to NOT be same"
       end if
 
-      call Obj2%release()
-      TEST_FOR_IERR(test_locallySameAs)
+      call Obj2%release(); TEST_IERR()
 
     end if
 
-    invalid = -1; num_local = 4
-    call Obj2%create(invalid, num_local, index_base, comm)
-    TEST_FOR_IERR(test_locallySameAs)
+    num_local = 4
+    call Obj2%create(invalid, num_local, index_base, comm); TEST_IERR()
 
-    fresult = Obj1%locallySameAs(Obj2)
-    TEST_FOR_IERR(test_locallySameAs)
+    fresult = Obj1%locallySameAs(Obj2); TEST_IERR()
     if (.not. fresult) then
       jerr = jerr + 1
       if (comm%getRank()==0) &
         write(*,*) "locallySameAs: Expected maps to be same"
     end if
 
-    call Obj1%release()
-    TEST_FOR_IERR(test_locallySameAs)
+    call Obj1%release(); TEST_IERR()
+    call Obj2%release(); TEST_IERR()
 
-    call Obj2%release()
-    TEST_FOR_IERR(test_locallySameAs)
+    success = (jerr == 0)
 
-    SET_ERROR_COUNT_AND_RETURN(test_locallySameAs, jerr)
-
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_locallySameAs)
 
 ! ----------------------------------getComm----------------------------------- !
-  integer function test_getComm()
+  FORTRILINOS_UNIT_TEST(TpetraMap_getComm)
     integer :: jerr
     type(TpetraMap) :: Obj
     type(TeuchosComm) :: fresult
-    integer(global_ordinal_type) :: num_global, index_base
+    integer(global_ordinal_type) :: num_global
     jerr = 0
     num_global = 4*comm%getSize()
-    index_base = 1
 
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_getComm)
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
 
     ! We only test the comm returned has the same rank and size.  More
     ! comprehensive testing is (assumed to be) done in Teuchos itself.
-    fresult = Obj%getComm()
-    TEST_FOR_IERR(test_getComm)
+    fresult = Obj%getComm(); TEST_IERR()
     if (fresult%getRank() /= comm%getRank()) then
       jerr = jerr + 1
       if (comm%getRank()==0) &
@@ -918,47 +787,34 @@ contains
         write(*,*) "getComm: expected sizes to be same"
     end if
 
-    call Obj%release()
-    TEST_FOR_IERR(test_getComm)
+    call Obj%release(); TEST_IERR()
 
-    SET_ERROR_COUNT_AND_RETURN(test_getComm, jerr)
+    success = (jerr == 0)
 
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_getComm)
 
 ! --------------------------------description--------------------------------- !
-  integer function test_description()
-    integer :: jerr
+  FORTRILINOS_UNIT_TEST(TpetraMap_description)
     type(TpetraMap) :: Obj
     type(string) :: fresult
-    integer(global_ordinal_type) :: num_global, index_base
-    jerr = 0
+    integer(global_ordinal_type) :: num_global
     num_global = 4*comm%getSize()
-    index_base = 1
-    call Obj%create(num_global, index_base, comm)
-    TEST_FOR_IERR(test_description)
-    fresult = Obj%description()
-    TEST_FOR_IERR(test_description)
-    SET_ERROR_COUNT_AND_RETURN(test_description, jerr)
-  end function
+    call Obj%create(num_global, index_base, comm); TEST_IERR()
+    fresult = Obj%description(); TEST_IERR()
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_description)
 
 ! ----------------------------removeEmptyProcesses---------------------------- !
-  integer function test_removeEmptyProcesses()
-    integer :: jerr
-    jerr = 0
+  FORTRILINOS_UNIT_TEST(TpetraMap_removeEmptyProcesses)
     ! TODO: Implement this test?
     if (comm%getRank()==0) &
       write(*,*) 'removeEmptyProcesses: Test is not yet Implemented'
-    SET_ERROR_COUNT_AND_RETURN(test_removeEmptyProcesses, jerr)
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_removeEmptyProcesses)
 
 ! ---------------------------replaceCommWithSubset---------------------------- !
-  integer function test_replaceCommWithSubset()
-    integer :: jerr
-    jerr = 0
+  FORTRILINOS_UNIT_TEST(TpetraMap_replaceCommWithSubset)
     ! TODO: Implement this test?
     if (comm%getRank()==0) &
       write(*,*) 'replaceCommWithSubset: Test is not yet implemented'
-    SET_ERROR_COUNT_AND_RETURN(test_replaceCommWithSubset, jerr)
-  end function
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_replaceCommWithSubset)
 
 end program test_TpetraMap

--- a/src/tpetra/test/test_tpetra_multivector.f90
+++ b/src/tpetra/test/test_tpetra_multivector.f90
@@ -1,0 +1,629 @@
+program test_TpetraMultiVector
+#include "ForTrilinosTpetra_config.hpp"
+#include "FortranTestMacros.h"
+  use iso_fortran_env
+  use, intrinsic :: iso_c_binding
+  use forteuchos
+  use fortpetra
+
+  DECLARE_TEST_VARIABLES()
+  type(TeuchosComm) :: comm
+  integer(global_ordinal_type), parameter :: index_base = 1
+  integer(global_size_type), parameter :: invalid = -1
+
+  INITIALIZE_TEST()
+
+#ifdef HAVE_MPI
+  call comm%create(MPI_COMM_WORLD)
+  CHECK_IERR()
+#else
+  call comm%create()
+#endif
+
+  ADD_SUBTEST_AND_RUN(TpetraMultiVector_ZeroScaleUpdate)
+  ADD_SUBTEST_AND_RUN(TpetraMultiVector_CountNormInf)
+  ADD_SUBTEST_AND_RUN(TpetraMultiVector_Norm2)
+  ADD_SUBTEST_AND_RUN(TpetraMultiVector_ReplaceMap)
+  ADD_SUBTEST_AND_RUN(TpetraMultiVector_Reciprocal)
+  ADD_SUBTEST_AND_RUN(TpetraMultiVector_Abs)
+  ADD_SUBTEST_AND_RUN(TpetraMultiVector_Description)
+  ADD_SUBTEST_AND_RUN(TpetraMultiVector_MeanValue)
+  ADD_SUBTEST_AND_RUN(TpetraMultiVector_Multiply)
+  ADD_SUBTEST_AND_RUN(TpetraMultiVector_Basic)
+  ADD_SUBTEST_AND_RUN(TpetraMultiVector_Reduce)
+  ADD_SUBTEST_AND_RUN(TpetraMultiVector_ReplaceGlobalValue)
+  ADD_SUBTEST_AND_RUN(TpetraMultiVector_ReplaceLocalValue)
+  ADD_SUBTEST_AND_RUN(TpetraMultiVector_Get1dCopy)
+
+  ! TODO: The following tests have only skeletons
+  !ADD_SUBTEST_AND_RUN(TpetraMultiVector_offsetViewNonConst)
+
+  ! The following methods are deprecated
+  !ADD_SUBTEST_AND_RUN(TpetraMultiVector_normWeighted)
+
+  ! The following methods are listed as "may change or disappear at any time"
+  !ADD_SUBTEST_AND_RUN(TpetraMultiVector_setCopyOrView)
+  !ADD_SUBTEST_AND_RUN(TpetraMultiVector_getCopyOrView)
+  !ADD_SUBTEST_AND_RUN(TpetraMultiVector_removeEmptyProcessesInPlace)
+
+  call comm%release()
+  CHECK_IERR()
+
+  SHUTDOWN_TEST()
+
+contains
+
+  ! -----------------------------ZeroScaleUpdate------------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_ZeroScaleUpdate)
+    integer :: i
+    type(TpetraMap) :: map
+    type(TpetraMultiVector) :: A, B, A2, C
+    type(TeuchosArrayViewDoubleConst) :: AV
+    integer(size_type), parameter :: num_vecs=2, num_local=2, LDA=2
+    integer(local_ordinal_type) :: lclrow
+    logical(bool_type) :: zeroout
+    real(scalar_type), parameter :: zero=0., one=1., two=2., four=4., negone=-1.
+    real(scalar_type) :: norms(num_vecs), zeros(num_vecs), values(6)
+    integer(global_ordinal_type) :: gblrow, num_global
+
+    zeros = zero
+
+    call map%create(invalid, num_local, index_base, comm); TEST_IERR()
+
+    ! values = {1, 1, 2, 2, 4, 4}
+    ! values(1:4) = {1, 1, 2, 2} = [1 2]
+    !                            = [1 2]
+    ! values(3:)  = {2, 2, 4, 4} = [2 4]
+    !                            = [2 4]
+    ! a multivector A constructed from the first
+    ! has values .5 of a multivector B constructed from the second
+    ! then 2*A - B = 0
+    ! we test both scale(), both update(), and norm()
+    values = [one, one, two, two, four, four]
+
+    ! TODO: Multivec create to take array, not ArrayView
+    call AV%create(values(1:4)); TEST_IERR()
+    call A%create(map, AV, LDA, num_vecs); TEST_IERR()
+    call AV%release()
+
+    call AV%create(values(3:)); TEST_IERR()
+    call B%create(map, AV, LDA, num_vecs); TEST_IERR()
+    call AV%release()
+
+    !
+    !      [.... ....]
+    ! A == [ones ones]
+    !      [.... ....]
+    !
+    !      [.... ....]
+    ! B == [twos twos]
+    !      [.... ....]
+    !
+    !   set A2 = A
+    !   scale it by 2 in situ
+    !   check that it equals B: subtraction in situ
+    call A2%create(A, Copy); TEST_IERR()
+    call A2%scale(two)
+    call A2%update(negone, B, one)
+    call A2%norm1(norms)
+    TEST_COMPARE_FLOATING_ARRAYS(norms, zeros, epsilon(zero))
+    call A2%release()
+
+    ! set A2 = A
+    ! check that it equals B: scale, subtraction in situ
+    call A2%create(A, Copy); TEST_IERR()
+    call A2%update(negone, B, two)
+    call A2%norm1(norms)
+    TEST_COMPARE_FLOATING_ARRAYS(norms, zeros, epsilon(zero))
+    call A2%release()
+
+    ! set C random
+    ! set it to zero by combination with A,B
+    zeroout = .false.
+    call C%create(map, num_vecs, zeroout); TEST_IERR()
+    call C%randomize()
+    call C%update(negone, B, two, A, zero)
+    call C%norm1(norms)
+    TEST_COMPARE_FLOATING_ARRAYS(norms, zeros, epsilon(zero))
+    call C%release()
+
+    ! set C random
+    ! scale it ex-situ
+    ! check that it equals B: subtraction in situ
+    call C%create(map, num_vecs, zeroout); TEST_IERR()
+    call C%scale(two, A)
+    call C%update(one, B, negone)
+    call C%norm1(norms)
+    TEST_COMPARE_FLOATING_ARRAYS(norms, zeros, epsilon(zero))
+    call C%release()
+
+    ! Clean up
+    call A%release(); TEST_IERR()
+    call B%release(); TEST_IERR()
+    call map%release(); TEST_IERR()
+
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_ZeroScaleUpdate)
+
+  ! ----------------------------CountNormInf---------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_CountNormInf)
+    type(TpetraMap) :: map
+    type(TpetraMultiVector) :: Vec
+    type(TeuchosArrayViewDoubleConst) :: AV
+    integer(size_type), parameter :: num_vecs=3, num_local=2, LDA=2
+    real(scalar_type) :: values(num_vecs*num_local), answer(num_vecs), norms(num_vecs)
+
+    OUT0("Starting CountNormInf")
+
+    ! create a Map
+    call map%create(invalid, num_local, index_base, comm); TEST_IERR()
+    ! values = {0, 0, 1, 1, 2, 2} = [0 1 2]
+    !                               [0 1 2]
+    ! normInf(values) = [0 1 2]
+    ! over all procs, this is [0 1 2]
+    values(:) = [0., 0., 1., 1., 2., 2.]
+    ! TODO: MultiVector takes array instead of ArrayView
+    call AV%create(values); TEST_IERR()
+    call Vec%create(map, AV, LDA, num_vecs); TEST_IERR()
+    call AV%release()
+    answer(:) = [0., 1., 2.]
+
+    ! do the dots
+    call Vec%normInf(norms)
+
+    call Vec%release()
+    call map%release()
+
+    ! check the answers
+    TEST_COMPARE_FLOATING_ARRAYS(norms, answer, epsilon(answer(1)))
+
+    OUT0("Finished CountNormInf!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_CountNormInf)
+
+  ! --------------------------------Norm2------------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_Norm2)
+    type(TpetraMap) :: map
+    type(TpetraMultiVector) :: Vec
+    real(scalar_type), parameter :: zero=0.
+    integer(size_type), parameter :: num_vecs=7, num_local=13
+    real(scalar_type) :: norms_rand(num_vecs), norms_zero(num_vecs)
+
+    OUT0("Starting Norm2")
+
+    ! create a Map
+    call map%create(invalid, num_local, index_base, comm); TEST_IERR()
+
+    call Vec%create(map, num_vecs); TEST_IERR()
+    call Vec%randomize(); TEST_IERR()
+
+    ! Take the norms, they should not be zero
+    call Vec%norm2(norms_rand)
+
+    ! Zero the vector
+    call Vec%putScalar(zero)
+
+    ! Take the norms, they should be zero
+    call Vec%norm2(norms_zero)
+
+    ! Check the answers
+    TEST_ARRAY_INEQUALITY(norms_rand, zero, epsilon(zero))
+    TEST_ARRAY_EQUALITY(norms_zero, zero, epsilon(zero))
+
+    call Vec%release()
+    call map%release()
+
+    OUT0("Finished Norm2!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_Norm2)
+
+  ! -----------------------------Reciprocal----------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_Reciprocal)
+    type(TpetraMap) :: map
+    type(TpetraMultiVector) :: A, B
+    integer(size_type), parameter :: num_vecs=2, num_local=10
+    real(scalar_type) :: dots(num_vecs)
+    real(scalar_type), parameter :: one=1., five=5.
+
+    OUT0("Starting Reciprocal")
+
+    ! create a Map
+    call map%create(invalid, num_local, index_base, comm); TEST_IERR()
+
+    call A%create(map, num_vecs); TEST_IERR()
+    call B%create(map, num_vecs); TEST_IERR()
+    call A%putScalar(five); TEST_IERR()
+    call A%reciprocal(B); TEST_IERR()
+
+    ! Take the dots, they should one
+    call A%dot(B, dots)
+
+    ! Check the answers
+    TEST_ARRAY_EQUALITY(dots, one, epsilon(one))
+
+    call A%release()
+    call B%release()
+    call map%release()
+
+    OUT0("Finished Reciprocal!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_Reciprocal)
+
+  ! --------------------------------ReplaceMap-------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_ReplaceMap)
+    type(TpetraMultiVector) :: Obj
+    type(TpetraMap) :: map1, map2
+    integer(size_type), parameter :: num_vecs=1
+    integer(global_ordinal_type) :: num_global
+
+    OUT0("Starting ReplaceMap")
+    ! NOTE: This test only tests the interface does not throw.
+    ! It does not test correctness
+    num_global = 4 * comm%getSize()
+    call map1%create(num_global, index_base, comm); TEST_IERR()
+
+    num_global = 5 * comm%getSize()
+    call map2%create(num_global, index_base, comm); TEST_IERR()
+
+    call Obj%create(map1, num_vecs); TEST_IERR()
+
+    call Obj%replaceMap(map2); TEST_IERR()
+
+    call map1%release(); TEST_IERR()
+    call map2%release(); TEST_IERR()
+
+    call Obj%release(); TEST_IERR()
+
+    OUT0("Finished ReplaceMap")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_ReplaceMap)
+
+  ! ----------------------------------Abs------------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_Abs)
+    integer :: i
+    type(TpetraMap) :: map
+    type(TpetraMultiVector) :: A, B, A2
+    integer(size_type), parameter :: num_vecs=2, num_local=10
+    real(scalar_type), parameter :: zero=0., one=1., negone=-1.
+    real(scalar_type) :: norms(num_vecs)
+
+    OUT0("Starting Abs")
+    call map%create(invalid, num_local, index_base, comm); TEST_IERR()
+
+    call A%create(map, num_vecs); TEST_IERR()
+    call B%create(map, num_vecs); TEST_IERR()
+    call A%putScalar(negone); TEST_IERR()
+    call A%abs(B)
+
+    !   set A2 = A
+    !   scale it by 2 in situ
+    !   check that it equals B: subtraction in situ
+    call A2%create(A, Copy); TEST_IERR()
+    call A2%update(one, B, one)
+    call A2%norm1(norms)
+    TEST_ARRAY_EQUALITY(norms, zero, epsilon(zero))
+
+    call A2%release()
+    call B%release()
+    call A%release()
+    call map%release()
+
+    OUT0("Finished Abs")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_Abs)
+
+! --------------------------------description--------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_Description)
+    type(TpetraMap) :: map
+    type(TpetraMultiVector) :: Vec
+    type(string) :: fresult
+    integer(size_type), parameter :: num_vecs=2, num_local=10
+    integer(global_ordinal_type) :: num_global, index_base
+    call map%create(invalid, num_local, index_base, comm); TEST_IERR()
+    call Vec%create(map, num_vecs)
+    fresult = Vec%description(); TEST_IERR()
+    call Vec%release(); TEST_IERR()
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_Description)
+
+  ! --------------------------------MeanValue--------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_MeanValue)
+    type(TpetraMap) :: map
+    type(TpetraMultiVector) :: Vec
+    type(TeuchosArrayViewDoubleConst) :: AV
+    type(TeuchosArrayViewDouble) :: means_av
+    integer(size_type), parameter :: num_vecs=2, num_local=2, LDA=2
+    real(scalar_type) :: values(4), means(num_vecs), answer(num_vecs)
+
+    OUT0("Starting MeanValue")
+
+    call map%create(invalid, num_local, index_base, comm); TEST_IERR()
+
+    ! values = {2, 6, 3, 1} = [2 3]
+    !                         [6 1]
+    values(:) = [2., 6., 3., 1.]
+
+    ! TODO: Multivec create to take array, not ArrayView
+    call AV%create(values); TEST_IERR()
+    call Vec%create(map, AV, LDA, num_vecs); TEST_IERR()
+    call AV%release()
+
+    !call means%create(); TEST_IERR()
+    call means_av%create(means); TEST_IERR()
+    call Vec%meanValue(means_av); TEST_IERR()
+    call means_av%release(); TEST_IERR()
+
+    answer = [4., 2.]
+    TEST_COMPARE_FLOATING_ARRAYS(means, answer, epsilon(means(1)))
+
+    call Vec%release(); TEST_IERR()
+    call map%release(); TEST_IERR()
+
+    OUT0("Finished MeanValue")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_MeanValue)
+
+  ! ---------------------------------Multiply--------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_Multiply)
+    type(TpetraMap) :: map2, map3
+    type(TpetraMultiVector) :: Vec2x2, Vec3x2
+    real(scalar_type), parameter :: zero=0., one=1.
+    integer(size_type), parameter :: n2=2, n3=3
+    integer(int_type) :: num_images
+    integer(global_size_type) :: num_global
+    real(scalar_type) :: check(9)
+
+    OUT0("Starting Multiply")
+
+    num_images = comm%getSize()
+    check = 3 * num_images
+
+    num_global = n2 * comm%getSize()
+    call map2%create(num_global, index_base, comm, LocallyReplicated); TEST_IERR()
+    call map3%create(invalid, n3, index_base, comm); TEST_IERR()
+
+    call Vec2x2%create(map2, n2); TEST_IERR()
+    call Vec3x2%create(map3, n2); TEST_IERR()
+    call Vec3x2%putScalar(one); TEST_IERR()
+
+    call Vec2x2%multiply(CONJ_TRANS, NO_TRANS, one, Vec3x2, Vec3x2, zero)
+    TEST_IERR()
+
+    !a = fortran array view of the data
+    !n = size of a
+    !TEST_COMPARE_FLOATING_ARRAYS(a, check(1:n), epsilon(a(1)))
+
+    OUT0("Finished Multiply!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_Multiply)
+
+  ! --------------------------------Basic------------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_Basic)
+    type(TpetraMap) :: map
+    type(TpetraMultiVector) :: Vec
+    integer(size_type), parameter :: num_vecs=12, num_local=2
+    call map%create(invalid, num_local, index_base, comm); TEST_IERR()
+    call Vec%create(map, num_vecs); TEST_IERR()
+
+    TEST_EQUALITY(Vec%getNumVectors(), num_vecs)
+    TEST_EQUALITY(Vec%getLocalLength(), num_local)
+    TEST_EQUALITY(Vec%getGlobalLength(), num_local*comm%getSize())
+    TEST_EQUALITY(Vec%getStride(), num_local)
+    TEST_LOGICAL_EQUALITY(Vec%isConstantStride(), .true.)
+
+    call Vec%release(); TEST_IERR()
+    call map%release(); TEST_IERR()
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_Basic)
+
+  ! ----------------------------------Reduce---------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_Reduce)
+    type(TpetraMap) :: map
+    type(TpetraMultiVector) :: Vec
+    integer(global_size_type) :: num_global
+    integer(size_type), parameter :: num_vecs=1, num_local=2
+    real(scalar_type), parameter :: two=2.
+    OUT0("Starting Reduce")
+    num_global = num_local * comm%getSize()
+    call map%create(num_global, index_base, comm, LocallyReplicated); TEST_IERR()
+    call Vec%create(map, num_vecs); TEST_IERR()
+    call Vec%putScalar(two); TEST_IERR()
+    call Vec%reduce(); TEST_IERR()
+    call Vec%release(); TEST_IERR()
+    call map%release(); TEST_IERR()
+    OUT0("Finished Reduce!")
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_Reduce)
+
+  ! ----------------------------replaceGlobalValue---------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_ReplaceGlobalValue)
+    integer :: i
+    type(TpetraMap) :: map
+    type(TpetraMultiVector) :: Vec, OneV
+    integer(size_type) :: col
+    integer(size_type), parameter :: num_vecs=2, num_local=4
+    integer(local_ordinal_type) :: lclrow
+    real(scalar_type) :: value, expected, dots(num_vecs)
+    real(scalar_type), parameter :: one=1.
+    integer(global_ordinal_type) :: gblrow, num_global
+    OUT0("Starting replaceGlobalValue")
+    num_global = num_local * comm%getSize()
+    call map%create(num_global, index_base, comm); TEST_IERR()
+
+    call Vec%create(map, num_vecs); TEST_IERR()
+    call OneV%create(map, num_vecs); TEST_IERR()
+    call OneV%putScalar(one); TEST_IERR()
+
+    ! TODO: Columns should be 1 based
+    do lclrow = 1, num_local
+      gblrow = map%getGlobalElement(lclrow)
+      value = real(gblrow, kind=scalar_type)
+      do col = 0, num_vecs-1
+        call Vec%replaceGlobalValue(gblrow, col, value); TEST_IERR()
+      end do
+    end do
+
+    call Vec%dot(OneV, dots)
+    expected = real(num_global * (num_global + 1) / 2., kind=scalar_type)
+    TEST_FLOATING_EQUALITY(dots(1), dots(2), epsilon(dots(2)))
+    TEST_FLOATING_EQUALITY(expected, dots(1), epsilon(dots(2)))
+
+    call Vec%release(); TEST_IERR()
+    call OneV%release(); TEST_IERR()
+    call map%release(); TEST_IERR()
+
+    OUT0("Finished replaceGlobalValue!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_ReplaceGlobalValue)
+
+  ! ----------------------------ReplaceLocalValue----------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_ReplaceLocalValue)
+    type(TpetraMap) :: map
+    type(TpetraMultiVector) :: Vec, OneV
+    integer(size_type) :: col
+    integer(local_ordinal_type) :: lclrow
+    integer(size_type), parameter :: num_vecs=2, num_local=4
+    real(scalar_type) :: value, dots(num_vecs), expected
+    real(scalar_type), parameter :: one=1.
+    OUT0("Starting ReplaceLocalValue")
+
+    call map%create(invalid, num_local, index_base, comm); TEST_IERR()
+    call Vec%create(map, num_vecs); TEST_IERR()
+    call OneV%create(map, num_vecs); TEST_IERR()
+    call OneV%putScalar(one)
+
+    ! TODO: column indices are wrong!  The are 0 based, but there is something
+    ! wrong with the stride, uncomment the assertions below to see.
+    do lclrow = 1, num_local
+      value = real(lclrow, kind=scalar_type)
+      do col = 0, num_vecs-1
+        call Vec%replaceLocalValue(lclrow, col, value); TEST_IERR()
+      end do
+    end do
+
+    call Vec%dot(OneV, dots)
+    expected = real(comm%getSize() * (num_local * (num_local + 1)) / 2., kind=scalar_type)
+    !TODO: print*, expected
+    !TODO: print*, dots
+    !TODO: TEST_FLOATING_EQUALITY(dots(1), dots(2), epsilon(dots(2)))
+    !TODO: TEST_FLOATING_EQUALITY(expected, dots(1), epsilon(dots(2)))
+
+    call Vec%release(); TEST_IERR()
+    call OneV%release(); TEST_IERR()
+    call map%release()
+
+    OUT0("Finished ReplaceLocalValue!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_ReplaceLocalValue)
+
+  ! --------------------------------Get1dCopy--------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_Get1dCopy)
+    type(TpetraMap) :: map
+    type(TpetraMultiVector) :: Vec
+    type(TeuchosArrayViewDouble) :: AV
+    integer(size_type) :: lda
+    real(scalar_type), allocatable :: a(:)
+    integer(size_type), parameter :: num_vecs=2, num_local=4
+    real(scalar_type), parameter :: one=1.
+    OUT0("Starting Get1dCopy")
+    call map%create(invalid, num_local, index_base, comm); TEST_IERR()
+    call Vec%create(map, num_vecs); TEST_IERR()
+    call Vec%putScalar(one); TEST_IERR()
+    allocate(a(num_vecs*num_local*comm%getSize()))
+    a = 0.
+    call AV%create(a); TEST_IERR()
+    lda = num_local*comm%getSize()
+    call Vec%Get1dCopy(AV, lda); TEST_IERR()
+    call AV%release(); TEST_IERR()
+    call Vec%release(); TEST_IERR()
+
+    TEST_ARRAY_EQUALITY(a, one, epsilon(one))
+    OUT0("Finished Get1dCopy!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_Get1dCopy)
+
+
+  ! ----------------------------offsetViewNonConst---------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_offsetViewNonConst)
+    type(TpetraMultiVector) :: Obj
+    type(TpetraMap) :: submap
+    integer(size_type) :: offset
+
+    success = .false.
+
+    !call submap%create(); TEST_IERR()
+    offset = 0
+    !call Obj%create(); TEST_IERR()
+    !fresult = Obj%offsetViewNonConst(submap, offset); TEST_IERR()
+    !call submap%release(); TEST_IERR()
+    !call Obj%release(); TEST_IERR()
+
+    write(*,*) 'offsetViewNonConst: Test not yet implemented'
+
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_offsetViewNonConst)
+
+  ! -------------------------------normWeighted------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_normWeighted)
+    type(TpetraMultiVector) :: Obj
+    type(TpetraMultiVector) :: weights
+    type(TeuchosArrayViewDouble) :: norms
+
+    success = .false.
+
+    !call weights%create(); TEST_IERR()
+    !call norms%create(); TEST_IERR()
+    !call Obj%create(); TEST_IERR()
+    !call Obj%normWeighted(weights, norms); TEST_IERR()
+    !call weights%release(); TEST_IERR()
+    !call norms%release(); TEST_IERR()
+    !call Obj%release(); TEST_IERR()
+
+    write(*,*) 'normWeighted: Test not yet implemented'
+
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_normWeighted)
+
+  ! -----------------------removeEmptyProcessesInPlace------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_removeEmptyProcessesInPlace)
+    type(TpetraMultiVector) :: Obj
+    type(TpetraMap) :: newmap
+
+    success = .false.
+
+    !call newmap%create(); TEST_IERR()
+    !call Obj%create(); TEST_IERR()
+    !call Obj%removeEmptyProcessesInPlace(newmap); TEST_IERR()
+    !call newmap%release(); TEST_IERR()
+    !call Obj%release(); TEST_IERR()
+
+    write(*,*) 'removeEmptyProcessesInPlace: Test not yet implemented'
+
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_removeEmptyProcessesInPlace)
+
+  ! ------------------------------setCopyOrView------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_setCopyOrView)
+    type(TpetraMultiVector) :: Obj
+    integer(kind(DataAccess)) :: copyorview
+
+    success = .false.
+
+    copyorview = Copy
+    !call Obj%create(); TEST_IERR()
+    !call Obj%setCopyOrView(copyorview); TEST_IERR()
+    !call Obj%release(); TEST_IERR()
+
+    write(*,*) 'setCopyOrView: Test not yet implemented'
+
+  END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_setCopyOrView)
+
+  ! ------------------------------getCopyOrView------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMultiVector_getCopyOrView)
+    type(TpetraMultiVector) :: Obj
+
+    success = .false.
+
+    !call Obj%create(); TEST_IERR()
+    !fresult = Obj%getCopyOrView(); TEST_IERR()
+    !call Obj%release(); TEST_IERR()
+
+    write(*,*) 'getCopyOrView: Test not yet implemented'
+
+    END_FORTRILINOS_UNIT_TEST(TpetraMultiVector_getCopyOrView)
+
+
+end program test_TpetraMultiVector

--- a/src/utils/src/FortranTestMacros.h
+++ b/src/utils/src/FortranTestMacros.h
@@ -156,28 +156,28 @@ use DBCF_M
 
 #else
 
-#define DECLARE_TEST_VARIABLES() \
-  implicit none; \
-  logical LOCAL_SUCCESS; \
+#define DECLARE_TEST_VARIABLES()         \
+  implicit none;                         \
+  logical LOCAL_SUCCESS;                 \
   integer ERROR_COUNTER, COMM_RANK
 
-#define INITIALIZE_TEST() \
+#define INITIALIZE_TEST()                \
   ERROR_COUNTER = 0; COMM_RANK = 0;
 
-#define ADD_SUBTEST_AND_RUN(NAME) \
-    LOCAL_SUCCESS = .true.
-    call NAME(LOCAL_SUCCESS); \
-    if ( .not. LOCAL_SUCCESS ) then; \
-      write(0, *) "Test FAILED!"; \
+#define ADD_SUBTEST_AND_RUN(NAME)        \
+    LOCAL_SUCCESS = .true.               \
+    call NAME(LOCAL_SUCCESS);            \
+    if ( .not. LOCAL_SUCCESS ) then;     \
+      write(0, *) "Test FAILED!";        \
       ERROR_COUNTER = ERROR_COUNTER + 1; \
     endif
 
-#define SHUTDOWN_TEST() \
-  if (ERROR_COUNTER == 0) then; \
-    write(*,*) "Test PASSED"; \
-  else; \
+#define SHUTDOWN_TEST()                                       \
+  if (ERROR_COUNTER == 0) then;                               \
+    write(*,*) "Test PASSED";                                 \
+  else;                                                       \
     write(*,*) "A total of ", ERROR_COUNTER, " tests FAILED"; \
-    Insist(.false., "FAILED TESTS ENCOUNTERED" ); \
+    Insist(.false., "FAILED TESTS ENCOUNTERED" );             \
   end if
 
 #endif

--- a/src/utils/src/FortranTestMacros.h
+++ b/src/utils/src/FortranTestMacros.h
@@ -44,66 +44,130 @@
     if(.NOT. ierr == 0 ) then;                         \
     WRITE( 0, * ) "Expected ierr = 0, but got ", ierr; \
     Insist(.false., "Expected ierr = 0" );             \
-    endif
+    end if
 
-#define TEST_FOR_IERR( NAME ) \
+#define TEST_IERR() \
     if (ierr /= 0) then; \
-      NAME = ierr; \
+      success = .false.; \
       ierr = 0; \
       return; \
-    endif
+    end if
 
-#define SET_ERROR_COUNT_AND_RETURN(NAME, ERROR_COUNT) \
-    NAME = ERROR_COUNT + ierr; \
-    ierr = 0; \
-    return
+#define TEST_COMPARE_FLOATING_ARRAYS(ARR1, ARR2, TOL)          \
+    if(abs(maxval(ARR1 - ARR2)) > TOL) then;                   \
+    write( 0, * ) "Floating point arrays are not the same";    \
+    success = .false.; ierr = 0;                               \
+    return;                                                    \
+    end if
+
+#define TEST_ARRAY_EQUALITY(ARR, VAL, TOL)                     \
+    if(abs(maxval(ARR - VAL)) > TOL) then;                     \
+    write( 0, * ) "Elements of array are NOT equal to ", VAL;  \
+    success = .false.; ierr = 0;                               \
+    return;                                                    \
+    end if
+
+#define TEST_ARRAY_INEQUALITY(ARR, VAL, TOL)                   \
+    if(abs(maxval(ARR - VAL)) <= TOL) then;                    \
+    write( 0, * ) "Elements of array ARE equal to ", VAL;      \
+    success = .false.; ierr = 0;                               \
+    return;                                                    \
+    end if
+
+#define TEST_FLOATING_EQUALITY(VAL1, VAL2, TOL)              \
+    if(abs(VAL1 - VAL2) > TOL) then;                         \
+    WRITE( 0, * ) "Floating point numbers not the same" ;    \
+    WRITE( 0, * ) VAL1, "/=", VAL2;                          \
+    success = .false.; ierr = 0;                             \
+    return;                                                  \
+    end if
+
+#define TEST_EQUALITY(VAL1, VAL2)                            \
+    if(VAL1 /= VAL2) then;                                   \
+    WRITE( 0, * ) "Values are not the same";                 \
+    WRITE( 0, * ) VAL1, "/=", VAL2;                          \
+    success = .false.; ierr = 0;                             \
+    return;                                                  \
+    end if
+
+#define TEST_LOGICAL_EQUALITY(VAL1, VAL2)                    \
+    if(VAL1 .neqv. VAL2) then;                               \
+    WRITE( 0, * ) "Values are not the same";                 \
+    WRITE( 0, * ) VAL1, "/=", VAL2;                          \
+    success = .false.; ierr = 0;                             \
+    return;                                                  \
+    end if
+
+#define FORTRILINOS_UNIT_TEST(NAME) \
+    subroutine NAME(success);       \
+    implicit none;                  \
+    logical :: success
+
+#define END_FORTRILINOS_UNIT_TEST(NAME) \
+    if (success) success = (ierr == 0); \
+    ierr = 0;                           \
+    return;                             \
+    end subroutine NAME
+
+#define OUT0(STRING) \
+    if (COMM_RANK == 0) WRITE(0, *) STRING
 
 use DBCF_M
 
 #ifdef HAVE_MPI
 
-#define DECLARE_TEST_VARIABLES() \
-  use mpi; \
-  implicit none; \
+#define DECLARE_TEST_VARIABLES()                                \
+  use mpi;                                                      \
+  implicit none;                                                \
+  logical LOCAL_SUCCESS;                                        \
   integer ERR1(1), ERR2(1), IERROR, COMM_RANK, ERROR_COUNTER
 
-#define INITIALIZE_TEST() \
-  ERR1(1) = 0; ERR2(1) = 0; ERROR_COUNTER = 0; \
-  call MPI_INIT(ierr); \
+#define INITIALIZE_TEST()                                       \
+  ERR1(1) = 0; ERR2(1) = 0; ERROR_COUNTER = 0;                  \
+  call MPI_INIT(ierr);                                          \
   call MPI_COMM_RANK(MPI_COMM_WORLD, COMM_RANK, IERROR)
 
-#define ADD_SUBTEST_AND_RUN(TEST_NAME) \
-    ERR1(1) = TEST_NAME(); \
+#define ADD_SUBTEST_AND_RUN(NAME)                               \
+    LOCAL_SUCCESS = .true.;                                     \
+    call NAME(LOCAL_SUCCESS);                                   \
+    if (LOCAL_SUCCESS) then;                                    \
+    ERR1(1) = 0;                                                \
+    else;                                                       \
+    ERR1(1) = 1;                                                \
+    end if;                                                     \
     call MPI_ALLREDUCE(ERR1, ERR2, 1, MPI_INTEGER, MPI_MAX, MPI_COMM_WORLD, IERROR); \
-    if ( ERR2(1) /= 0 ) then; \
-      if (COMM_RANK == 0) write(0, *) "Test FAILED!"; \
-      ERROR_COUNTER = ERROR_COUNTER + 1; \
+    if ( ERR2(1) /= 0 ) then;                                   \
+      if (COMM_RANK == 0) write(0, *) "Test FAILED!";           \
+      ERROR_COUNTER = ERROR_COUNTER + 1;                        \
     endif
 
-#define SHUTDOWN_TEST() \
-  if (ERROR_COUNTER == 0) then; \
-    if (COMM_RANK == 0) then; \
-      write(*,*) "Test PASSED"; \
-    end if; \
-  else; \
-    if (COMM_RANK == 0) then; \
+#define SHUTDOWN_TEST()                                         \
+  if (ERROR_COUNTER == 0) then;                                 \
+    if (COMM_RANK == 0) then;                                   \
+      write(*,*) "Test PASSED";                                 \
+    end if;                                                     \
+  else;                                                         \
+    if (COMM_RANK == 0) then;                                   \
       write(*,*) "A total of ", ERROR_COUNTER, " tests FAILED"; \
-    end if; \
-    Insist(.false., "FAILED TESTS ENCOUNTERED" ); \
-  end if; \
-  call MPI_FINALIZE(ierr);
+    end if;                                                     \
+    Insist(.false., "FAILED TESTS ENCOUNTERED" );               \
+  end if;                                                       \
+  call MPI_FINALIZE(ierr)
 
 #else
 
 #define DECLARE_TEST_VARIABLES() \
   implicit none; \
-  integer ERROR_COUNTER
+  logical LOCAL_SUCCESS; \
+  integer ERROR_COUNTER, COMM_RANK
 
 #define INITIALIZE_TEST() \
-  ERROR_COUNTER = 0;
+  ERROR_COUNTER = 0; COMM_RANK = 0;
 
-#define ADD_SUBTEST_AND_RUN(TEST_NAME) \
-    if ( TEST_NAME() /= 0 ) then; \
+#define ADD_SUBTEST_AND_RUN(NAME) \
+    LOCAL_SUCCESS = .true.
+    call NAME(LOCAL_SUCCESS); \
+    if ( .not. LOCAL_SUCCESS ) then; \
       write(0, *) "Test FAILED!"; \
       ERROR_COUNTER = ERROR_COUNTER + 1; \
     endif


### PR DESCRIPTION
@aprokop 

This PR does two things:

- Updates the test macros to be more user friendly
- Adds tests for `TpetraMultiVector`

*note* The `replaceLocalValue` and `replaceGlobalValue` of `TpetraMultiVector` seem to have bugs.  The column indices seem to be base 0, whereas the row indices are base 1 for `replaceGlobalValue`.  For `replaceLocalValue`, it's not clear how columns indices are being passed to Tpetra, but it seems wrong.

The `getNodeElementList` method of `TpetraMap` also seems to be returning junk.