### PR TITLE
Workaround for .neqv. which does not seem to work with gnu 7.?

### DIFF
--- a/src/teuchos/test/test_teuchos_comm.f90
+++ b/src/teuchos/test/test_teuchos_comm.f90
@@ -29,13 +29,13 @@ contains
 
 #ifdef HAVE_MPI
     call comm%create(MPI_COMM_WORLD); TEST_IERR()
-    TEST_EQUALITY_CONST(c_associated(comm%swigptr), .true.)
+    TEST_ASSERT(c_associated(comm%swigptr))
 
     call MPI_COMM_RANK(MPI_COMM_WORLD, comm_rank_f, ierr)
     call MPI_COMM_SIZE(MPI_COMM_WORLD, comm_size_f, ierr)
 #else
     call comm%create(); TEST_IERR()
-    TEST_EQUALITY_CONST(c_associated(comm%swigptr), .true.)
+    TEST_ASSERT(c_associated(comm%swigptr))
 
     comm_rank_f = 0
     comm_size_f = 1

--- a/src/teuchos/test/test_teuchos_plist.f90
+++ b/src/teuchos/test/test_teuchos_plist.f90
@@ -33,11 +33,11 @@ contains
     OUT0('Starting TeuchosPList_Basic!')
 
     call plist%create('myname'); TEST_IERR()
-    TEST_EQUALITY_CONST(c_associated(plist%swigptr), .true.)
+    TEST_ASSERT(c_associated(plist%swigptr))
 
     ! Test a function that raises an exception
     TEST_THROW(call load_from_xml(plist, 'nonexistent_path.xml'))
-    TEST_EQUALITY_CONST(c_associated(plist%swigptr), .true.)
+    TEST_ASSERT(c_associated(plist%swigptr))
 
     ! Get and set a vlaue
     call plist%set('myint', 4)
@@ -51,7 +51,7 @@ contains
     bval = .false.
     call plist%set('mybool', true)
     call plist%get('mybool', bval)
-    TEST_EQUALITY_CONST(bval, true)
+    TEST_ASSERT(bval)
 
     call plist%set('intarr', test_int)
     call plist%set('dblarr', test_dbl)
@@ -66,14 +66,14 @@ contains
     TEST_THROW(call plist%get('intarr', test_int(:4)))
 
     call plist%set('deleteme', 123)
-    TEST_EQUALITY_CONST(plist%is_parameter('deleteme'), true)
+    TEST_ASSERT(plist%is_parameter('deleteme'))
 
     call plist%remove('deleteme')
-    TEST_EQUALITY_CONST(plist%is_parameter('deleteme'), false)
+    TEST_ASSERT((.not. plist%is_parameter('deleteme')))
 
-    TEST_EQUALITY_CONST(c_associated(sublist%swigptr), .false.)
+    TEST_ASSERT((.not. c_associated(sublist%swigptr)))
     sublist = plist%sublist('sublist')
-    TEST_EQUALITY_CONST(c_associated(sublist%swigptr), .true.)
+    TEST_ASSERT(c_associated(sublist%swigptr))
 
     call sublist%set('anotherval', 4.0d0)
 

--- a/src/tpetra/test/test_tpetra_crsgraph.f90
+++ b/src/tpetra/test/test_tpetra_crsgraph.f90
@@ -170,7 +170,7 @@ contains
     OUT0("Starting TpetraCrsGraph_WithColMap!")
 
     num_procs = comm%getSize()
-    !if (num_procs == 1) return
+    if (num_procs == 1) return
 
     num_local = 1
     call rmap%create(invalid, num_local, comm); TEST_IERR()
@@ -178,7 +178,7 @@ contains
     ! must allocate enough for all submitted indices.
     num_ent_per_row = 2
     call Graph%create(rmap, cmap, num_ent_per_row, StaticProfile)
-    TEST_EQUALITY_CONST(Graph%hasColMap(), true)
+    TEST_ASSERT(Graph%hasColMap())
     lclrow = 1
     myrowind = rmap%getGlobalElement(lclrow);
 
@@ -239,7 +239,7 @@ contains
     colind(1:2) = [1, 2]
 
     call Graph%create(rmap, rmap, rowptr, colind)
-    TEST_EQUALITY_CONST(Graph%hasColMap(), true)
+    TEST_ASSERT(Graph%hasColMap())
 
     TEST_NOTHROW(call Graph%expertStaticFillComplete(rmap, rmap))
 
@@ -286,7 +286,7 @@ contains
     call Graph%create(rmap, rmap, izero, StaticProfile)
 
     TEST_NOTHROW(call Graph%setAllIndices(rowptr, colind))
-    TEST_EQUALITY_CONST(Graph%hasColMap(), true )
+    TEST_ASSERT(Graph%hasColMap())
 
     TEST_NOTHROW(call Graph%expertStaticFillComplete(rmap,rmap))
 
@@ -330,7 +330,7 @@ contains
 
     nument = 4
     call Graph%create(map, map, nument);
-    TEST_EQUALITY_CONST(graph%isSorted(), true)
+    TEST_ASSERT(graph%isSorted())
 
     ! insert entries; shouldn't be sorted anymore
     jstart = map%getMinGlobalIndex()
@@ -349,7 +349,7 @@ contains
       end if
       call Graph%insertGlobalIndices(j, jinds(1:jj))
     end do
-    TEST_EQUALITY_CONST(Graph%isSorted(), false)
+    TEST_ASSERT((.not. Graph%isSorted()))
     deallocate(jinds)
 
     ! fill complete; should be sorted now
@@ -370,13 +370,13 @@ contains
           exit
         endif
       end do
-      TEST_EQUALITY_CONST(sorting_check, graph%isSorted())
+      TEST_ASSERT((sorting_check .eqv. graph%isSorted()))
       deallocate(kinds)
     end do
 
     ! resume fill; should still be sorted
     call Graph%resumeFill()
-    TEST_EQUALITY_CONST(graph%isSorted(), true)
+    TEST_ASSERT(graph%isSorted())
 
     sorting_check = true
     kstart = map%getMinLocalIndex()
@@ -391,7 +391,7 @@ contains
           exit
         endif
       end do
-      TEST_EQUALITY_CONST(sorting_check, graph%isSorted())
+      TEST_ASSERT((sorting_check .eqv. graph%isSorted()))
       deallocate(kinds)
     end do
 
@@ -401,7 +401,7 @@ contains
     allocate(kinds(1))
     kinds(1) = 1
     call Graph%insertLocalIndices(k, kinds)
-    TEST_EQUALITY_CONST(graph%isSorted(), false);
+    TEST_ASSERT((.not. graph%isSorted()))
     deallocate(kinds)
 
     ! fill complete, check one more time
@@ -421,7 +421,7 @@ contains
           exit
         endif
       end do
-      TEST_EQUALITY_CONST(sorting_check, graph%isSorted())
+      TEST_ASSERT((sorting_check .eqv. graph%isSorted()))
       deallocate(kinds)
     end do
 
@@ -478,7 +478,7 @@ contains
     OUT0("Starting TpetraCrsGraph_GetEntities!")
 
     num_procs = comm%getSize()
-    !if (num_procs == 1) return
+    if (num_procs == 1) return
 
     num_local = 1
     call rmap%create(invalid, num_local, comm); TEST_IERR()
@@ -486,7 +486,7 @@ contains
     ! must allocate enough for all submitted indices.
     num_ent_per_row = 2
     call Graph%create(rmap, cmap, num_ent_per_row, StaticProfile)
-    TEST_EQUALITY_CONST(Graph%hasColMap(), true)
+    TEST_ASSERT(Graph%hasColMap())
     lclrow = 1
     myrowind = rmap%getGlobalElement(lclrow);
 

--- a/src/utils/src/FortranTestUtilities.h
+++ b/src/utils/src/FortranTestUtilities.h
@@ -171,12 +171,6 @@ use fortest
  CALL FORTEST_ASSERT(SUCCESS, FILENAME, __LINE__, "C", C); \
  IF (.NOT.SUCCESS) THEN; IERR = 0; RETURN; ENDIF
 
-! Checks that condition C is X and toggles success to .FALSE. if not.  If
-! the SUCCESS flag is toggled, the test is exited
-#define TEST_EQUALITY_CONST(C, X) \
- CALL FORTEST_EQUALITY_CONST(SUCCESS, FILENAME, __LINE__, "C", C, "X", X); \
- IF (.NOT.SUCCESS) THEN; IERR = 0; RETURN; ENDIF
-
 ! Checks that instruction CODE throws an exception toggles success to .FALSE. if
 ! not.  If the SUCCESS flag is toggled, the test is exited
 #define TEST_THROW(CODE) \

--- a/src/utils/src/fortest.f90
+++ b/src/utils/src/fortest.f90
@@ -897,7 +897,7 @@ contains
     logical :: lcl_success
     ! ------------------------------------------------------------------------ !
     name = 'TEST_EQUALITY_CONST'
-    !lcl_success = (a .neqv. b)
+    !lcl_success = (a .eqv. b)
     lcl_success = eqv1(a, b)
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//')'
@@ -921,7 +921,7 @@ contains
     logical :: lcl_success
     ! ------------------------------------------------------------------------ !
     name = 'TEST_EQUALITY_CONST'
-    !lcl_success = (a .neqv. b)
+    !lcl_success = (a .eqv. b)
     lcl_success = eqv2(a, b)
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//')'

--- a/src/utils/src/fortest.f90
+++ b/src/utils/src/fortest.f90
@@ -299,6 +299,30 @@ contains
 
   ! -------------------------------------------------------------------------- !
 
+  ! A bug in gfortran causes .neqv. to evaluate incorrectly, so we implement
+  ! a function to replace it
+  logical function eqv1(a, b)
+    logical(c_bool), intent(in) :: a, b
+    integer :: ia, ib
+    ia = merge(0, 1, a); ib = merge(0, 1, b)
+    eqv1 = (ia == ib)
+    return
+  end function eqv1
+
+  ! -------------------------------------------------------------------------- !
+
+  ! A bug in gfortran causes .neqv. to evaluate incorrectly, so we implement
+  ! a function to replace it
+  logical function eqv2(a, b)
+    logical, intent(in) :: a, b
+    integer :: ia, ib
+    ia = merge(0, 1, a); ib = merge(0, 1, b)
+    eqv2 = (ia == ib)
+    return
+  end function eqv2
+
+  ! -------------------------------------------------------------------------- !
+
   subroutine fortest_ierr(success, filename, lineno, ierr, serr)
     ! ------------------------------------------------------------------------ !
     logical, intent(inout) :: success
@@ -873,11 +897,11 @@ contains
     logical :: lcl_success
     ! ------------------------------------------------------------------------ !
     name = 'TEST_EQUALITY_CONST'
-    lcl_success = .true.
-    if (a .neqv. b) then
+    !lcl_success = (a .neqv. b)
+    lcl_success = eqv1(a, b)
+    if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//')'
       call write_error_diagnostics(filename, lineno, signature)
-      lcl_success = .false.
     end if
     call gather_success(lcl_success, success)
     return
@@ -897,11 +921,11 @@ contains
     logical :: lcl_success
     ! ------------------------------------------------------------------------ !
     name = 'TEST_EQUALITY_CONST'
-    lcl_success = .true.
-    if (a .neqv. b) then
+    !lcl_success = (a .neqv. b)
+    lcl_success = eqv2(a, b)
+    if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//')'
       call write_error_diagnostics(filename, lineno, signature)
-      lcl_success = .false.
     end if
     call gather_success(lcl_success, success)
     return

--- a/src/utils/src/fortest.f90
+++ b/src/utils/src/fortest.f90
@@ -396,6 +396,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_FLOATING_ARRAY_EQUALITY'
     lcl_success = (abs(maxval(a - b)) <= tolerance)
+    if (any(isnan(a)) .or. any(isnan(b))) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -420,6 +421,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_FLOATING_ARRAY_EQUALITY'
     lcl_success = (abs(maxval(a - b)) <= tolerance)
+    if (any(isnan(a)) .or. isnan(b)) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -444,6 +446,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_EQUALITY'
     lcl_success = (abs(maxval(a - b)) <= zero)
+    if (any(isnan(a)) .or. any(isnan(b))) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -468,6 +471,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_EQUALITY'
     lcl_success = (abs(maxval(a - b)) <= zero)
+    if (any(isnan(a)) .or. isnan(b)) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -492,6 +496,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_EQUALITY'
     lcl_success = (abs(maxval(a - b)) <= zero)
+    if (any(isnan(a)) .or. any(isnan(b))) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -516,6 +521,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_EQUALITY'
     lcl_success = (abs(maxval(a - b)) <= zero)
+    if (any(isnan(a)) .or. isnan(b)) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -541,6 +547,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_EQUALITY'
     lcl_success = (abs(maxval(a - b)) <= zero)
+    if (any(isnan(a)) .or. any(isnan(b))) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -567,6 +574,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_EQUALITY'
     lcl_success = (abs(maxval(a - b)) <= zero)
+    if (any(isnan(a)) .or. any(isnan(b))) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -593,6 +601,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_EQUALITY'
     lcl_success = (abs(maxval(a - b)) <= zero)
+    if (any(isnan(a)) .or. any(isnan(b))) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -619,6 +628,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_EQUALITY'
     lcl_success = (abs(maxval(a - b)) <= zero)
+    if (any(isnan(a)) .or. any(isnan(b))) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -644,6 +654,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_FLOATING_ARRAY_INEQUALITY'
     lcl_success = (abs(maxval(a - b)) > tolerance)
+    if (any(isnan(a)) .or. any(isnan(b))) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -668,6 +679,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_INEQUALITY'
     lcl_success = (abs(maxval(a - b)) > tolerance)
+    if (any(isnan(a)) .or. isnan(b)) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -692,6 +704,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_INEQUALITY'
     lcl_success = (abs(maxval(a - b)) > zero)
+    if (any(isnan(a)) .or. any(isnan(b))) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -716,6 +729,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_INEQUALITY'
     lcl_success = (abs(maxval(a - b)) > zero)
+    if (any(isnan(a)) .or. isnan(b)) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -739,6 +753,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_INEQUALITY'
     lcl_success = (abs(maxval(a - b)) > zero)
+    if (any(isnan(a)) .or. any(isnan(b))) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -763,6 +778,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_INEQUALITY'
     lcl_success = (abs(maxval(a - b)) > zero)
+    if (any(isnan(a)) .or. isnan(b)) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -788,6 +804,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_INEQUALITY'
     lcl_success = (abs(maxval(a - b)) > zero)
+    if (any(isnan(a)) .or. any(isnan(b))) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -814,6 +831,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_INEQUALITY'
     lcl_success = (abs(maxval(a - b)) > zero)
+    if (any(isnan(a)) .or. any(isnan(b))) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -840,6 +858,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_INEQUALITY'
     lcl_success = (abs(maxval(a - b)) > zero)
+    if (any(isnan(a)) .or. any(isnan(b))) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)
@@ -866,6 +885,7 @@ contains
     ! ------------------------------------------------------------------------ !
     name = 'TEST_ARRAY_INEQUALITY'
     lcl_success = (abs(maxval(a - b)) > zero)
+    if (any(isnan(a)) .or. any(isnan(b))) lcl_success = .false.
     if (.not. lcl_success) then
       signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//', TOL)'
       call write_error_diagnostics(filename, lineno, signature)

--- a/src/utils/src/fortest.f90
+++ b/src/utils/src/fortest.f90
@@ -46,18 +46,6 @@ implicit none
 integer, private :: comm_rank, failed_tests, total_tests
 logical, private :: setup_called = .false.
 
-interface fortest_equality_const
-  module procedure fortest_equality_const1, fortest_equality_const2
-end interface
-
-interface bool_to_int
-  module procedure bool_to_int1, bool_to_int2
-end interface
-
-interface fortest_eqv
-  module procedure fortest_eqv1, fortest_eqv2
-end interface
-
 interface fortest_array_equality
   module procedure fortest_array_equality_double1, &
                    fortest_array_equality_double2, &
@@ -316,48 +304,6 @@ contains
     ! ------------------------------------------------------------------------ !
     if (comm_rank == 0) write(output_unit, '(A)') trim(string)
   end subroutine write_to_proc0
-
-  ! -------------------------------------------------------------------------- !
-
-  integer function bool_to_int1(x)
-    logical(c_bool), intent(in) :: x
-    if (.not. x) then
-      bool_to_int1 = 0
-    else
-      bool_to_int1 = 1
-    endif
-  end function bool_to_int1
-
-  ! -------------------------------------------------------------------------- !
-
-  integer function bool_to_int2(x)
-    logical, intent(in) :: x
-    if (.not. x) then
-      bool_to_int2 = 0
-    else
-      bool_to_int2 = 1
-    endif
-  end function bool_to_int2
-
-  ! -------------------------------------------------------------------------- !
-
-  ! A bug in gfortran causes .neqv. to evaluate incorrectly, so we implement
-  ! a function to replace it
-  logical function fortest_eqv1(a, b)
-    logical(c_bool), intent(in) :: a, b
-    fortest_eqv1 = (bool_to_int(a) == bool_to_int(b))
-    return
-  end function fortest_eqv1
-
-  ! -------------------------------------------------------------------------- !
-
-  ! A bug in gfortran causes .neqv. to evaluate incorrectly, so we implement
-  ! a function to replace it
-  logical function fortest_eqv2(a, b)
-    logical, intent(in) :: a, b
-    fortest_eqv2 = (bool_to_int(a) == bool_to_int(b))
-    return
-  end function fortest_eqv2
 
   ! -------------------------------------------------------------------------- !
 
@@ -1213,54 +1159,6 @@ contains
     return
   end subroutine fortest_inequality_size_t1
 #endif
-
-  ! -------------------------------------------------------------------------- !
-
-  subroutine fortest_equality_const1(success, filename, lineno, &
-                                     namea, a, nameb, b)
-    ! ------------------------------------------------------------------------ !
-    logical, intent(inout) :: success
-    character(len=*), intent(in) :: filename, namea, nameb
-    integer, intent(in) :: lineno
-    logical(c_bool), intent(in) :: a, b
-    character(len=30) :: name
-    character(len=256) :: signature
-    logical :: lcl_success
-    ! ------------------------------------------------------------------------ !
-    name = 'TEST_EQUALITY_CONST'
-    !lcl_success = (a .eqv. b)
-    lcl_success = fortest_eqv(a, b)
-    if (.not. lcl_success) then
-      signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//')'
-      call write_error_diagnostics(filename, lineno, signature)
-    end if
-    call gather_success(lcl_success, success)
-    return
-  end subroutine fortest_equality_const1
-
-  ! -------------------------------------------------------------------------- !
-
-  subroutine fortest_equality_const2(success, filename, lineno, &
-                                    namea, a, nameb, b)
-    ! ------------------------------------------------------------------------ !
-    logical, intent(inout) :: success
-    character(len=*), intent(in) :: filename, namea, nameb
-    integer, intent(in) :: lineno
-    logical, intent(in) :: a, b
-    character(len=30) :: name
-    character(len=256) :: signature
-    logical :: lcl_success
-    ! ------------------------------------------------------------------------ !
-    name = 'TEST_EQUALITY_CONST'
-    !lcl_success = (a .eqv. b)
-    lcl_success = fortest_eqv(a, b)
-    if (.not. lcl_success) then
-      signature = trim(name)//'('//trim(namea)//', '//trim(nameb)//')'
-      call write_error_diagnostics(filename, lineno, signature)
-    end if
-    call gather_success(lcl_success, success)
-    return
-  end subroutine fortest_equality_const2
 
   ! -------------------------------------------------------------------------- !
 


### PR DESCRIPTION
@aprokop, this is a very simple workaround for the issues you are seeing with gnu 7.2 w.r.t. `.neqv.`.   I'm on my laptop at the moment and don't have access to 7.2, so I have only tested in 6.4, but this workaround avoids `.neqv.` altogether without changing user code.

Addresses: #170