### PR TITLE
Tpetra: remove duplicated functions in Writer

### DIFF
--- a/src/tpetra/src/Tpetra_InOut.i
+++ b/src/tpetra/src/Tpetra_InOut.i
@@ -79,14 +79,6 @@
       std::string filenameStr(filename.first, filename.second);
       Tpetra::MatrixMarket::Writer<CMT>::writeSparseFile(filenameStr, pMatrix, debug);
     }
-    static void writeSparseGraphFile (std::pair<const char*, size_t> filename, const crs_graph_type &graph, const std::string &graphName, const std::string &graphDescription, const bool debug=false) {
-      std::string filenameStr(filename.first, filename.second);
-      Tpetra::MatrixMarket::Writer<CMT>::writeSparseGraphFile(filenameStr, graph, graphName, graphDescription, debug);
-    }
-    static void writeSparseGraphFile (std::pair<const char*, size_t> filename, const crs_graph_type &graph, const bool debug=false) {
-      std::string filenameStr(filename.first, filename.second);
-      Tpetra::MatrixMarket::Writer<CMT>::writeSparseGraphFile(filenameStr, graph, debug);
-    }
     static void writeSparseGraphFile (std::pair<const char*, size_t> filename, const Teuchos::RCP< const crs_graph_type > &pGraph, const std::string &graphName, const std::string &graphDescription, const bool debug=false) {
       std::string filenameStr(filename.first, filename.second);
       Tpetra::MatrixMarket::Writer<CMT>::writeSparseGraphFile(filenameStr, pGraph, graphName, graphDescription, debug);

--- a/src/tpetra/src/fortpetra.f90
+++ b/src/tpetra/src/fortpetra.f90
@@ -577,18 +577,13 @@ end type
   procedure, private, nopass :: writeSparseGraphFile__SWIG_1 => swigf_TpetraWriter_writeSparseGraphFile__SWIG_1
   procedure, private, nopass :: writeSparseGraphFile__SWIG_2 => swigf_TpetraWriter_writeSparseGraphFile__SWIG_2
   procedure, private, nopass :: writeSparseGraphFile__SWIG_3 => swigf_TpetraWriter_writeSparseGraphFile__SWIG_3
-  procedure, private, nopass :: writeSparseGraphFile__SWIG_4 => swigf_TpetraWriter_writeSparseGraphFile__SWIG_4
-  procedure, private, nopass :: writeSparseGraphFile__SWIG_5 => swigf_TpetraWriter_writeSparseGraphFile__SWIG_5
-  procedure, private, nopass :: writeSparseGraphFile__SWIG_6 => swigf_TpetraWriter_writeSparseGraphFile__SWIG_6
-  procedure, private, nopass :: writeSparseGraphFile__SWIG_7 => swigf_TpetraWriter_writeSparseGraphFile__SWIG_7
   procedure, private, nopass :: writeMapFile__SWIG_1 => swigf_TpetraWriter_writeMapFile__SWIG_1
   procedure :: create => swigf_new_TpetraWriter
   procedure :: release => swigf_delete_TpetraWriter
   procedure, private :: swigf_assign_TpetraWriter
   generic :: assignment(=) => swigf_assign_TpetraWriter
   generic :: writeSparseGraphFile => writeSparseGraphFile__SWIG_0, writeSparseGraphFile__SWIG_1, writeSparseGraphFile__SWIG_2, &
-    writeSparseGraphFile__SWIG_3, writeSparseGraphFile__SWIG_4, writeSparseGraphFile__SWIG_5, writeSparseGraphFile__SWIG_6, &
-    writeSparseGraphFile__SWIG_7
+    writeSparseGraphFile__SWIG_3
   generic :: writeMapFile => writeMapFile__SWIG_0, writeMapFile__SWIG_1
   generic :: writeSparseFile => writeSparseFile__SWIG_0, writeSparseFile__SWIG_1, writeSparseFile__SWIG_2, &
     writeSparseFile__SWIG_3
@@ -3776,44 +3771,6 @@ end subroutine
 
 subroutine swigc_TpetraWriter_writeSparseGraphFile__SWIG_3(farg1, farg2) &
 bind(C, name="swigc_TpetraWriter_writeSparseGraphFile__SWIG_3")
-use, intrinsic :: ISO_C_BINDING
-import :: SwigfArrayWrapper
-type(SwigfArrayWrapper) :: farg1
-type(C_PTR), value :: farg2
-end subroutine
-
-subroutine swigc_TpetraWriter_writeSparseGraphFile__SWIG_4(farg1, farg2, farg3, farg4, farg5) &
-bind(C, name="swigc_TpetraWriter_writeSparseGraphFile__SWIG_4")
-use, intrinsic :: ISO_C_BINDING
-import :: SwigfArrayWrapper
-type(SwigfArrayWrapper) :: farg1
-type(C_PTR), value :: farg2
-type(C_PTR), value :: farg3
-type(C_PTR), value :: farg4
-logical(C_BOOL), intent(in) :: farg5
-end subroutine
-
-subroutine swigc_TpetraWriter_writeSparseGraphFile__SWIG_5(farg1, farg2, farg3, farg4) &
-bind(C, name="swigc_TpetraWriter_writeSparseGraphFile__SWIG_5")
-use, intrinsic :: ISO_C_BINDING
-import :: SwigfArrayWrapper
-type(SwigfArrayWrapper) :: farg1
-type(C_PTR), value :: farg2
-type(C_PTR), value :: farg3
-type(C_PTR), value :: farg4
-end subroutine
-
-subroutine swigc_TpetraWriter_writeSparseGraphFile__SWIG_6(farg1, farg2, farg3) &
-bind(C, name="swigc_TpetraWriter_writeSparseGraphFile__SWIG_6")
-use, intrinsic :: ISO_C_BINDING
-import :: SwigfArrayWrapper
-type(SwigfArrayWrapper) :: farg1
-type(C_PTR), value :: farg2
-logical(C_BOOL), intent(in) :: farg3
-end subroutine
-
-subroutine swigc_TpetraWriter_writeSparseGraphFile__SWIG_7(farg1, farg2) &
-bind(C, name="swigc_TpetraWriter_writeSparseGraphFile__SWIG_7")
 use, intrinsic :: ISO_C_BINDING
 import :: SwigfArrayWrapper
 type(SwigfArrayWrapper) :: farg1
@@ -9609,10 +9566,10 @@ farg2 = pmatrix%swigptr
 call swigc_TpetraWriter_writeSparseFile__SWIG_3(farg1, farg2)
 end subroutine
 
-subroutine swigf_TpetraWriter_writeSparseGraphFile__SWIG_0(filename, graph, graphname, graphdescription, debug)
+subroutine swigf_TpetraWriter_writeSparseGraphFile__SWIG_0(filename, pgraph, graphname, graphdescription, debug)
 use, intrinsic :: ISO_C_BINDING
 character(kind=C_CHAR, len=*), target :: filename
-class(TpetraCrsGraph) :: graph
+type(TpetraCrsGraph) :: pgraph
 class(string) :: graphname
 class(string) :: graphdescription
 logical(C_BOOL), intent(in) :: debug
@@ -9624,17 +9581,17 @@ logical(C_BOOL) :: farg5
 
 farg1%data = c_loc(filename)
 farg1%size = len(filename)
-farg2 = graph%swigptr
+farg2 = pgraph%swigptr
 farg3 = graphname%swigptr
 farg4 = graphdescription%swigptr
 farg5 = debug
 call swigc_TpetraWriter_writeSparseGraphFile__SWIG_0(farg1, farg2, farg3, farg4, farg5)
 end subroutine
 
-subroutine swigf_TpetraWriter_writeSparseGraphFile__SWIG_1(filename, graph, graphname, graphdescription)
+subroutine swigf_TpetraWriter_writeSparseGraphFile__SWIG_1(filename, pgraph, graphname, graphdescription)
 use, intrinsic :: ISO_C_BINDING
 character(kind=C_CHAR, len=*), target :: filename
-class(TpetraCrsGraph) :: graph
+type(TpetraCrsGraph) :: pgraph
 class(string) :: graphname
 class(string) :: graphdescription
 type(SwigfArrayWrapper) :: farg1 
@@ -9644,16 +9601,16 @@ type(C_PTR) :: farg4
 
 farg1%data = c_loc(filename)
 farg1%size = len(filename)
-farg2 = graph%swigptr
+farg2 = pgraph%swigptr
 farg3 = graphname%swigptr
 farg4 = graphdescription%swigptr
 call swigc_TpetraWriter_writeSparseGraphFile__SWIG_1(farg1, farg2, farg3, farg4)
 end subroutine
 
-subroutine swigf_TpetraWriter_writeSparseGraphFile__SWIG_2(filename, graph, debug)
+subroutine swigf_TpetraWriter_writeSparseGraphFile__SWIG_2(filename, pgraph, debug)
 use, intrinsic :: ISO_C_BINDING
 character(kind=C_CHAR, len=*), target :: filename
-class(TpetraCrsGraph) :: graph
+type(TpetraCrsGraph) :: pgraph
 logical(C_BOOL), intent(in) :: debug
 type(SwigfArrayWrapper) :: farg1 
 type(C_PTR) :: farg2 
@@ -9661,92 +9618,22 @@ logical(C_BOOL) :: farg3
 
 farg1%data = c_loc(filename)
 farg1%size = len(filename)
-farg2 = graph%swigptr
+farg2 = pgraph%swigptr
 farg3 = debug
 call swigc_TpetraWriter_writeSparseGraphFile__SWIG_2(farg1, farg2, farg3)
 end subroutine
 
-subroutine swigf_TpetraWriter_writeSparseGraphFile__SWIG_3(filename, graph)
+subroutine swigf_TpetraWriter_writeSparseGraphFile__SWIG_3(filename, pgraph)
 use, intrinsic :: ISO_C_BINDING
 character(kind=C_CHAR, len=*), target :: filename
-class(TpetraCrsGraph) :: graph
+type(TpetraCrsGraph) :: pgraph
 type(SwigfArrayWrapper) :: farg1 
 type(C_PTR) :: farg2 
 
 farg1%data = c_loc(filename)
 farg1%size = len(filename)
-farg2 = graph%swigptr
+farg2 = pgraph%swigptr
 call swigc_TpetraWriter_writeSparseGraphFile__SWIG_3(farg1, farg2)
-end subroutine
-
-subroutine swigf_TpetraWriter_writeSparseGraphFile__SWIG_4(filename, pgraph, graphname, graphdescription, debug)
-use, intrinsic :: ISO_C_BINDING
-character(kind=C_CHAR, len=*), target :: filename
-type(TpetraCrsGraph) :: pgraph
-class(string) :: graphname
-class(string) :: graphdescription
-logical(C_BOOL), intent(in) :: debug
-type(SwigfArrayWrapper) :: farg1 
-type(C_PTR) :: farg2 
-type(C_PTR) :: farg3 
-type(C_PTR) :: farg4 
-logical(C_BOOL) :: farg5 
-
-farg1%data = c_loc(filename)
-farg1%size = len(filename)
-farg2 = pgraph%swigptr
-farg3 = graphname%swigptr
-farg4 = graphdescription%swigptr
-farg5 = debug
-call swigc_TpetraWriter_writeSparseGraphFile__SWIG_4(farg1, farg2, farg3, farg4, farg5)
-end subroutine
-
-subroutine swigf_TpetraWriter_writeSparseGraphFile__SWIG_5(filename, pgraph, graphname, graphdescription)
-use, intrinsic :: ISO_C_BINDING
-character(kind=C_CHAR, len=*), target :: filename
-type(TpetraCrsGraph) :: pgraph
-class(string) :: graphname
-class(string) :: graphdescription
-type(SwigfArrayWrapper) :: farg1 
-type(C_PTR) :: farg2 
-type(C_PTR) :: farg3 
-type(C_PTR) :: farg4 
-
-farg1%data = c_loc(filename)
-farg1%size = len(filename)
-farg2 = pgraph%swigptr
-farg3 = graphname%swigptr
-farg4 = graphdescription%swigptr
-call swigc_TpetraWriter_writeSparseGraphFile__SWIG_5(farg1, farg2, farg3, farg4)
-end subroutine
-
-subroutine swigf_TpetraWriter_writeSparseGraphFile__SWIG_6(filename, pgraph, debug)
-use, intrinsic :: ISO_C_BINDING
-character(kind=C_CHAR, len=*), target :: filename
-type(TpetraCrsGraph) :: pgraph
-logical(C_BOOL), intent(in) :: debug
-type(SwigfArrayWrapper) :: farg1 
-type(C_PTR) :: farg2 
-logical(C_BOOL) :: farg3 
-
-farg1%data = c_loc(filename)
-farg1%size = len(filename)
-farg2 = pgraph%swigptr
-farg3 = debug
-call swigc_TpetraWriter_writeSparseGraphFile__SWIG_6(farg1, farg2, farg3)
-end subroutine
-
-subroutine swigf_TpetraWriter_writeSparseGraphFile__SWIG_7(filename, pgraph)
-use, intrinsic :: ISO_C_BINDING
-character(kind=C_CHAR, len=*), target :: filename
-type(TpetraCrsGraph) :: pgraph
-type(SwigfArrayWrapper) :: farg1 
-type(C_PTR) :: farg2 
-
-farg1%data = c_loc(filename)
-farg1%size = len(filename)
-farg2 = pgraph%swigptr
-call swigc_TpetraWriter_writeSparseGraphFile__SWIG_7(farg1, farg2)
 end subroutine
 
 subroutine swigf_TpetraWriter_writeMapFile__SWIG_1(filename, map)

--- a/src/tpetra/src/fortpetraFORTRAN_wrap.cxx
+++ b/src/tpetra/src/fortpetraFORTRAN_wrap.cxx
@@ -606,19 +606,11 @@ SWIGINTERN void Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseFile__SWIG_2(st
       std::string filenameStr(filename.first, filename.second);
       Tpetra::MatrixMarket::Writer<CMT>::writeSparseFile(filenameStr, pMatrix, debug);
     }
-SWIGINTERN void Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_0(std::pair< char const *,std::size_t > filename,Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type const &graph,std::string const &graphName,std::string const &graphDescription,bool const debug=false){
-      std::string filenameStr(filename.first, filename.second);
-      Tpetra::MatrixMarket::Writer<CMT>::writeSparseGraphFile(filenameStr, graph, graphName, graphDescription, debug);
-    }
-SWIGINTERN void Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_2(std::pair< char const *,std::size_t > filename,Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type const &graph,bool const debug=false){
-      std::string filenameStr(filename.first, filename.second);
-      Tpetra::MatrixMarket::Writer<CMT>::writeSparseGraphFile(filenameStr, graph, debug);
-    }
-SWIGINTERN void Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_4(std::pair< char const *,std::size_t > filename,Teuchos::RCP< Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type const > const &pGraph,std::string const &graphName,std::string const &graphDescription,bool const debug=false){
+SWIGINTERN void Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_0(std::pair< char const *,std::size_t > filename,Teuchos::RCP< Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type const > const &pGraph,std::string const &graphName,std::string const &graphDescription,bool const debug=false){
       std::string filenameStr(filename.first, filename.second);
       Tpetra::MatrixMarket::Writer<CMT>::writeSparseGraphFile(filenameStr, pGraph, graphName, graphDescription, debug);
     }
-SWIGINTERN void Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_6(std::pair< char const *,std::size_t > filename,Teuchos::RCP< Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type const > const &pGraph,bool const debug=false){
+SWIGINTERN void Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_2(std::pair< char const *,std::size_t > filename,Teuchos::RCP< Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type const > const &pGraph,bool const debug=false){
       std::string filenameStr(filename.first, filename.second);
       Tpetra::MatrixMarket::Writer<CMT>::writeSparseGraphFile(filenameStr, pGraph, debug);
     }
@@ -14329,187 +14321,7 @@ SWIGEXPORT void swigc_TpetraWriter_writeSparseFile__SWIG_3(swig::SwigfArrayWrapp
 }
 
 
-SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_0(swig::SwigfArrayWrapper< char const > *farg1, void const *farg2, void const *farg3, void const *farg4, bool const *farg5) {
-  std::pair< char const *,std::size_t > arg1 ;
-  Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type *arg2 = 0 ;
-  std::string *arg3 = 0 ;
-  std::string *arg4 = 0 ;
-  bool arg5 ;
-  
-  arg1 = ::std::pair< const char*, std::size_t >();
-  (&arg1)->first  = farg1->data;
-  (&arg1)->second = farg1->size;
-  arg2 = (Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type *)(((Teuchos::RCP<const Tpetra::CrsGraph<LO,GO,NO,NO::classic> > *)farg2)
-    ? ((Teuchos::RCP<const Tpetra::CrsGraph<LO,GO,NO,NO::classic> > *)farg2)->get()
-    :0);
-  if (!arg2)
-  {
-    throw std::logic_error("Attempt to dereference null Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type const &");
-    return ;
-  }
-  arg3 = static_cast< std::string * >(const_cast< void* >(farg3));
-  arg4 = static_cast< std::string * >(const_cast< void* >(farg4));
-  arg5 = *farg5;
-  {
-    // Make sure no unhandled exceptions exist before performing a new action
-    swig::fortran_check_unhandled_exception();
-    try
-    {
-      // Attempt the wrapped function call
-      Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_0(arg1,(Tpetra::CrsGraph< int,long long,Kokkos::Compat::KokkosSerialWrapperNode > const &)*arg2,(std::string const &)*arg3,(std::string const &)*arg4,arg5);
-    }
-    catch (const std::range_error& e)
-    {
-      // Store a C++ exception
-      SWIG_exception_impl(SWIG_IndexError, e.what(), );
-    }
-    catch (const std::exception& e)
-    {
-      // Store a C++ exception
-      SWIG_exception_impl(SWIG_RuntimeError, e.what(), );
-    }
-    catch (...)
-    {
-      SWIG_exception_impl(SWIG_UnknownError, "An unknown exception occurred", );
-    }
-  }
-  
-}
-
-
-SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_1(swig::SwigfArrayWrapper< char const > *farg1, void const *farg2, void const *farg3, void const *farg4) {
-  std::pair< char const *,std::size_t > arg1 ;
-  Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type *arg2 = 0 ;
-  std::string *arg3 = 0 ;
-  std::string *arg4 = 0 ;
-  
-  arg1 = ::std::pair< const char*, std::size_t >();
-  (&arg1)->first  = farg1->data;
-  (&arg1)->second = farg1->size;
-  arg2 = (Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type *)(((Teuchos::RCP<const Tpetra::CrsGraph<LO,GO,NO,NO::classic> > *)farg2)
-    ? ((Teuchos::RCP<const Tpetra::CrsGraph<LO,GO,NO,NO::classic> > *)farg2)->get()
-    :0);
-  if (!arg2)
-  {
-    throw std::logic_error("Attempt to dereference null Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type const &");
-    return ;
-  }
-  arg3 = static_cast< std::string * >(const_cast< void* >(farg3));
-  arg4 = static_cast< std::string * >(const_cast< void* >(farg4));
-  {
-    // Make sure no unhandled exceptions exist before performing a new action
-    swig::fortran_check_unhandled_exception();
-    try
-    {
-      // Attempt the wrapped function call
-      Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_0(arg1,(Tpetra::CrsGraph< int,long long,Kokkos::Compat::KokkosSerialWrapperNode > const &)*arg2,(std::string const &)*arg3,(std::string const &)*arg4);
-    }
-    catch (const std::range_error& e)
-    {
-      // Store a C++ exception
-      SWIG_exception_impl(SWIG_IndexError, e.what(), );
-    }
-    catch (const std::exception& e)
-    {
-      // Store a C++ exception
-      SWIG_exception_impl(SWIG_RuntimeError, e.what(), );
-    }
-    catch (...)
-    {
-      SWIG_exception_impl(SWIG_UnknownError, "An unknown exception occurred", );
-    }
-  }
-  
-}
-
-
-SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_2(swig::SwigfArrayWrapper< char const > *farg1, void const *farg2, bool const *farg3) {
-  std::pair< char const *,std::size_t > arg1 ;
-  Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type *arg2 = 0 ;
-  bool arg3 ;
-  
-  arg1 = ::std::pair< const char*, std::size_t >();
-  (&arg1)->first  = farg1->data;
-  (&arg1)->second = farg1->size;
-  arg2 = (Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type *)(((Teuchos::RCP<const Tpetra::CrsGraph<LO,GO,NO,NO::classic> > *)farg2)
-    ? ((Teuchos::RCP<const Tpetra::CrsGraph<LO,GO,NO,NO::classic> > *)farg2)->get()
-    :0);
-  if (!arg2)
-  {
-    throw std::logic_error("Attempt to dereference null Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type const &");
-    return ;
-  }
-  arg3 = *farg3;
-  {
-    // Make sure no unhandled exceptions exist before performing a new action
-    swig::fortran_check_unhandled_exception();
-    try
-    {
-      // Attempt the wrapped function call
-      Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_2(arg1,(Tpetra::CrsGraph< int,long long,Kokkos::Compat::KokkosSerialWrapperNode > const &)*arg2,arg3);
-    }
-    catch (const std::range_error& e)
-    {
-      // Store a C++ exception
-      SWIG_exception_impl(SWIG_IndexError, e.what(), );
-    }
-    catch (const std::exception& e)
-    {
-      // Store a C++ exception
-      SWIG_exception_impl(SWIG_RuntimeError, e.what(), );
-    }
-    catch (...)
-    {
-      SWIG_exception_impl(SWIG_UnknownError, "An unknown exception occurred", );
-    }
-  }
-  
-}
-
-
-SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_3(swig::SwigfArrayWrapper< char const > *farg1, void const *farg2) {
-  std::pair< char const *,std::size_t > arg1 ;
-  Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type *arg2 = 0 ;
-  
-  arg1 = ::std::pair< const char*, std::size_t >();
-  (&arg1)->first  = farg1->data;
-  (&arg1)->second = farg1->size;
-  arg2 = (Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type *)(((Teuchos::RCP<const Tpetra::CrsGraph<LO,GO,NO,NO::classic> > *)farg2)
-    ? ((Teuchos::RCP<const Tpetra::CrsGraph<LO,GO,NO,NO::classic> > *)farg2)->get()
-    :0);
-  if (!arg2)
-  {
-    throw std::logic_error("Attempt to dereference null Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type const &");
-    return ;
-  }
-  {
-    // Make sure no unhandled exceptions exist before performing a new action
-    swig::fortran_check_unhandled_exception();
-    try
-    {
-      // Attempt the wrapped function call
-      Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_2(arg1,(Tpetra::CrsGraph< int,long long,Kokkos::Compat::KokkosSerialWrapperNode > const &)*arg2);
-    }
-    catch (const std::range_error& e)
-    {
-      // Store a C++ exception
-      SWIG_exception_impl(SWIG_IndexError, e.what(), );
-    }
-    catch (const std::exception& e)
-    {
-      // Store a C++ exception
-      SWIG_exception_impl(SWIG_RuntimeError, e.what(), );
-    }
-    catch (...)
-    {
-      SWIG_exception_impl(SWIG_UnknownError, "An unknown exception occurred", );
-    }
-  }
-  
-}
-
-
-SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_4(swig::SwigfArrayWrapper< char const > *farg1, void *farg2, void const *farg3, void const *farg4, bool const *farg5) {
+SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_0(swig::SwigfArrayWrapper< char const > *farg1, void *farg2, void const *farg3, void const *farg4, bool const *farg5) {
   std::pair< char const *,std::size_t > arg1 ;
   Teuchos::RCP< Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type const > *arg2 = 0 ;
   std::string *arg3 = 0 ;
@@ -14530,7 +14342,7 @@ SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_4(swig::SwigfArray
     try
     {
       // Attempt the wrapped function call
-      Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_4(arg1,(Teuchos::RCP< Tpetra::CrsGraph< int,long long,Kokkos::Compat::KokkosSerialWrapperNode > const > const &)*arg2,(std::string const &)*arg3,(std::string const &)*arg4,arg5);
+      Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_0(arg1,(Teuchos::RCP< Tpetra::CrsGraph< int,long long,Kokkos::Compat::KokkosSerialWrapperNode > const > const &)*arg2,(std::string const &)*arg3,(std::string const &)*arg4,arg5);
     }
     catch (const std::range_error& e)
     {
@@ -14551,7 +14363,7 @@ SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_4(swig::SwigfArray
 }
 
 
-SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_5(swig::SwigfArrayWrapper< char const > *farg1, void *farg2, void const *farg3, void const *farg4) {
+SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_1(swig::SwigfArrayWrapper< char const > *farg1, void *farg2, void const *farg3, void const *farg4) {
   std::pair< char const *,std::size_t > arg1 ;
   Teuchos::RCP< Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type const > *arg2 = 0 ;
   std::string *arg3 = 0 ;
@@ -14570,7 +14382,7 @@ SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_5(swig::SwigfArray
     try
     {
       // Attempt the wrapped function call
-      Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_4(arg1,(Teuchos::RCP< Tpetra::CrsGraph< int,long long,Kokkos::Compat::KokkosSerialWrapperNode > const > const &)*arg2,(std::string const &)*arg3,(std::string const &)*arg4);
+      Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_0(arg1,(Teuchos::RCP< Tpetra::CrsGraph< int,long long,Kokkos::Compat::KokkosSerialWrapperNode > const > const &)*arg2,(std::string const &)*arg3,(std::string const &)*arg4);
     }
     catch (const std::range_error& e)
     {
@@ -14591,7 +14403,7 @@ SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_5(swig::SwigfArray
 }
 
 
-SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_6(swig::SwigfArrayWrapper< char const > *farg1, void *farg2, bool const *farg3) {
+SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_2(swig::SwigfArrayWrapper< char const > *farg1, void *farg2, bool const *farg3) {
   std::pair< char const *,std::size_t > arg1 ;
   Teuchos::RCP< Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type const > *arg2 = 0 ;
   bool arg3 ;
@@ -14608,7 +14420,7 @@ SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_6(swig::SwigfArray
     try
     {
       // Attempt the wrapped function call
-      Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_6(arg1,(Teuchos::RCP< Tpetra::CrsGraph< int,long long,Kokkos::Compat::KokkosSerialWrapperNode > const > const &)*arg2,arg3);
+      Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_2(arg1,(Teuchos::RCP< Tpetra::CrsGraph< int,long long,Kokkos::Compat::KokkosSerialWrapperNode > const > const &)*arg2,arg3);
     }
     catch (const std::range_error& e)
     {
@@ -14629,7 +14441,7 @@ SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_6(swig::SwigfArray
 }
 
 
-SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_7(swig::SwigfArrayWrapper< char const > *farg1, void *farg2) {
+SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_3(swig::SwigfArrayWrapper< char const > *farg1, void *farg2) {
   std::pair< char const *,std::size_t > arg1 ;
   Teuchos::RCP< Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type const > *arg2 = 0 ;
   Teuchos::RCP< Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix< double,int,long long,Kokkos::Compat::KokkosSerialWrapperNode,Kokkos::Compat::KokkosSerialWrapperNode::classic > >::crs_graph_type const > tempnull2 ;
@@ -14644,7 +14456,7 @@ SWIGEXPORT void swigc_TpetraWriter_writeSparseGraphFile__SWIG_7(swig::SwigfArray
     try
     {
       // Attempt the wrapped function call
-      Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_6(arg1,(Teuchos::RCP< Tpetra::CrsGraph< int,long long,Kokkos::Compat::KokkosSerialWrapperNode > const > const &)*arg2);
+      Tpetra_MatrixMarket_Writer_Sl_CMT_Sg__writeSparseGraphFile__SWIG_2(arg1,(Teuchos::RCP< Tpetra::CrsGraph< int,long long,Kokkos::Compat::KokkosSerialWrapperNode > const > const &)*arg2);
     }
     catch (const std::range_error& e)
     {


### PR DESCRIPTION
The functions that take in A and RCP<A> are indistinguishable on Fortran
side.