### PR TITLE
Fixing issues uncovered by enabling Trilinos Debug mode

### DIFF
--- a/scripts/docker_cmake
+++ b/scripts/docker_cmake
@@ -10,6 +10,7 @@ ARGS=(
     -D BUILD_SHARED_LIBS=ON
 
     ### COMPILERS AND FLAGS ###
+    -D Trilinos_ENABLE_DEBUG=ON
     -D Trilinos_ENABLE_Fortran=ON
     -D Trilinos_TPL_SYSTEM_INCLUDE_DIRS=ON
     -D CMAKE_CXX_FLAGS="-Wall -Wpedantic"

--- a/src/tpetra/src/Tpetra_MultiVector.i
+++ b/src/tpetra/src/Tpetra_MultiVector.i
@@ -164,6 +164,17 @@
 %ignore Tpetra::MultiVector::get1dViewNonConst;
 
 
+// FIXME
+// For some unknown reason, the generated code for Multivector `release()` is
+// different from all other Tpetra classes (even from CrsMatrix which also has
+// a "classic" template argument). Specifically, the default release it was
+// generating was using "delete arg1;" instead of "(void) arg1; delete
+// smartarg1". This means that "unref" feature was not attached to it for some
+// reason.
+// Therefore, we explicitly attach it here to fix the generated wrapper code.
+%feature("unref") Tpetra::MultiVector<SC,LO,GO,NO>
+%{ (void)$self; delete smart$self; %}
+
 %teuchos_rcp(Tpetra::MultiVector<SC,LO,GO,NO,NO::classic>)
 
 %include "Tpetra_MultiVector_decl.hpp"

--- a/src/tpetra/src/fortpetraFORTRAN_wrap.cxx
+++ b/src/tpetra/src/fortpetraFORTRAN_wrap.cxx
@@ -3620,7 +3620,7 @@ SWIGEXPORT void swigc_delete_TpetraMultiVector(SwigfClassWrapper const *farg1) {
     try
     {
       // Attempt the wrapped function call
-      delete arg1;
+      (void)arg1; delete smartarg1; 
     }
     catch (const std::range_error& e)
     {

--- a/src/tpetra/test/test_tpetra_crsgraph.f90
+++ b/src/tpetra/test/test_tpetra_crsgraph.f90
@@ -347,7 +347,7 @@ contains
       if (map%isNodeGlobalElement(lastind)) then
         jinds(jj) = lastind; jj = jj + 1
       end if
-      call Graph%insertGlobalIndices(j, jinds(1:jj))
+      call Graph%insertGlobalIndices(j, jinds(1:jj-1))
     end do
     TEST_ASSERT((.not. Graph%isSorted()))
     deallocate(jinds)

--- a/src/tpetra/test/test_tpetra_map.f90
+++ b/src/tpetra/test/test_tpetra_map.f90
@@ -286,11 +286,8 @@ contains
     end if
     call Obj%release(); TEST_IERR()
 
-    ! All elements have 4 entries and map has only 4 entries so the map should
-    ! not be distributed
     num_global = 4
-    elements = [1, 2, 3, 4]
-    call Obj%create(num_global, elements, comm); TEST_IERR()
+    call Obj%create(num_global, comm, TpetraLocallyReplicated); TEST_IERR()
     TEST_ASSERT((.not. Obj%isDistributed()))
     call Obj%release(); TEST_IERR()
 

--- a/src/tpetra/test/test_tpetra_multivector.f90
+++ b/src/tpetra/test/test_tpetra_multivector.f90
@@ -348,9 +348,9 @@ contains
 
   ! ---------------------------------Multiply--------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraMultiVector_Multiply)
-    type(TpetraMap) :: map2, map3
-    type(TpetraMultiVector) :: Vec2x2, Vec3x2
-    real(scalar_type), parameter :: zero=0., one=1.
+    type(TpetraMap) :: map2n, map3n, lmap2, lmap3
+    type(TpetraMultiVector) :: mv3nx2, mv3nx3, mv2x2, mv2x3, mv3x2, mv3x3
+    real(scalar_type), parameter :: S0=0., S1=1.
     integer(size_type), parameter :: n2=2, n3=3
     integer(int_type) :: num_images
     integer(global_size_type) :: num_global
@@ -358,19 +358,27 @@ contains
 
     OUT0("Starting Multiply")
 
+    call map2n%create(invalid, n2, comm); TEST_IERR()
+    call map3n%create(invalid, n3, comm); TEST_IERR()
+
+    call lmap2%create(n2, comm, TpetraLocallyReplicated); TEST_IERR()
+    call lmap3%create(n3, comm, TpetraLocallyReplicated); TEST_IERR()
+
+    call mv3nx2%create(map3n, n2)
+    call mv3nx3%create(map3n, n3)
+
+    call mv2x2%create(lmap2, n2)
+    call mv2x3%create(lmap2, n3)
+    call mv3x2%create(lmap3, n2)
+    call mv3x3%create(lmap3, n3)
+
     num_images = comm%getSize()
     check = 3 * num_images
 
-    num_global = n2 * comm%getSize()
-    call map2%create(num_global, comm, TpetraLocallyReplicated); TEST_IERR()
-    call map3%create(invalid, n3, comm); TEST_IERR()
-
-    call Vec2x2%create(map2, n2); TEST_IERR()
-    call Vec3x2%create(map3, n2); TEST_IERR()
-    call Vec3x2%putScalar(one); TEST_IERR()
-
-    call Vec2x2%multiply(TEUCHOSCONJ_TRANS, TEUCHOSNO_TRANS, one, Vec3x2, Vec3x2, zero)
-    TEST_IERR()
+    call mv2x2%multiply(TEUCHOSCONJ_TRANS,TEUCHOSNO_TRANS,S1,mv3nx2,mv3nx2,S0); TEST_IERR()
+    call mv2x3%multiply(TEUCHOSCONJ_TRANS,TEUCHOSNO_TRANS,S1,mv3nx2,mv3nx3,S0); TEST_IERR()
+    call mv3x2%multiply(TEUCHOSCONJ_TRANS,TEUCHOSNO_TRANS,S1,mv3nx3,mv3nx2,S0); TEST_IERR()
+    call mv3x3%multiply(TEUCHOSCONJ_TRANS,TEUCHOSNO_TRANS,S1,mv3nx3,mv3nx3,S0); TEST_IERR()
 
     !a = fortran array view of the data
     !n = size of a


### PR DESCRIPTION
Apparently, we did not catch a bunch of errors in Tpetra tests. Tpetra is very lenient in default mode, but running with `-D Tpetra_ENABLE_DEBUG=ON` highlighted several incorrect usages and/or errors in our tpetra tests.