### PR TITLE
Teuchos::Comm improvements

### DIFF
--- a/src/teuchos/src/Teuchos_Comm.i
+++ b/src/teuchos/src/Teuchos_Comm.i
@@ -41,6 +41,12 @@ class Comm
 {
   public:
 
+    // Wrap built-in methods
+    int getRank() const;
+    int getSize() const;
+    void barrier() const;
+
+    // Add constructors
   %extend {
     Comm(MPI_Comm rawMpiComm) {
 %#ifdef HAVE_MPI
@@ -58,14 +64,6 @@ class Comm
 %#endif
     }
 
-    int getRank() const {
-      return $self->getRank();
-    }
-    int getSize() const {
-      return $self->getSize();
-    }
-    void barrier() const {
-      $self->barrier();
     }
   } // %extend
 };

--- a/src/teuchos/src/Teuchos_Comm.i
+++ b/src/teuchos/src/Teuchos_Comm.i
@@ -39,7 +39,7 @@
 %#ifdef HAVE_MPI
     $result = %static_cast(MPI_Comm_c2f($1), int);
 %#else
-    $1 = *$input;
+    $result = $1;
 %#endif
 }
 

--- a/src/teuchos/src/Teuchos_Comm.i
+++ b/src/teuchos/src/Teuchos_Comm.i
@@ -19,13 +19,13 @@
 %include <Teuchos_RCP.i>
 
 typedef int MPI_Comm;
-%typemap(in, noblock=1) MPI_Comm %{
-#ifdef HAVE_MPI
-    $1 = ($1_ltype)(MPI_Comm_f2c(*(MPI_Fint *)($input)));
-#else
+%typemap(in, noblock=1) MPI_Comm {
+%#ifdef HAVE_MPI
+    $1 = MPI_Comm_f2c(%static_cast(*$input, MPI_Fint));
+%#else
     $1 = *$input;
-#endif
-%}
+%#endif
+}
 
 // Make the Comm an RCP
 %teuchos_rcp(Teuchos::Comm<int>)

--- a/src/teuchos/src/Teuchos_Comm.i
+++ b/src/teuchos/src/Teuchos_Comm.i
@@ -18,10 +18,26 @@
 
 %include <Teuchos_RCP.i>
 
-typedef int MPI_Comm;
+%apply int { MPI_Comm };
+%typemap(ftype) MPI_Comm
+   "integer"
+%typemap(fin, noblock=1) MPI_Comm {
+    $1 = int($input, C_INT)
+}
+%typemap(fout, noblock=1) MPI_Comm {
+    $result = int($1)
+}
+
 %typemap(in, noblock=1) MPI_Comm {
 %#ifdef HAVE_MPI
     $1 = MPI_Comm_f2c(%static_cast(*$input, MPI_Fint));
+%#else
+    $1 = *$input;
+%#endif
+}
+%typemap(out, noblock=1) MPI_Comm {
+%#ifdef HAVE_MPI
+    $result = %static_cast(MPI_Comm_c2f($1), int);
 %#else
     $1 = *$input;
 %#endif
@@ -50,7 +66,7 @@ class Comm
   %extend {
     Comm(MPI_Comm rawMpiComm) {
 %#ifdef HAVE_MPI
-      return static_cast<Teuchos::Comm<Ordinal>*>(new Teuchos::MpiComm<int>(rawMpiComm));
+      return new Teuchos::MpiComm<Ordinal>(rawMpiComm);
 %#else
       throw std::runtime_error("MPI based constructor cannot be called when MPI is not enabled.");
 %#endif
@@ -58,12 +74,19 @@ class Comm
 
     Comm() {
 %#ifdef HAVE_MPI
-      return static_cast<Teuchos::Comm<Ordinal>*>(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
+      return new Teuchos::MpiComm<Ordinal>(MPI_COMM_WORLD);
 %#else
-      return static_cast<Teuchos::Comm<Ordinal>*>(new Teuchos::SerialComm<int>());
+      return new Teuchos::SerialComm<Ordinal>();
 %#endif
     }
 
+    MPI_Comm getRawMpiComm() {
+%#ifdef HAVE_MPI
+      Teuchos::MpiComm<Ordinal>& comm = dynamic_cast<Teuchos::MpiComm<Ordinal>&>(*$self);
+      return *comm.getRawMpiComm();
+%#else
+      throw std::runtime_error("MPI based constructor cannot be called when MPI is not enabled.");
+%#endif
     }
   } // %extend
 };

--- a/src/teuchos/src/forteuchos.f90
+++ b/src/teuchos/src/forteuchos.f90
@@ -183,6 +183,7 @@ end type
   procedure :: getRank => swigf_TeuchosComm_getRank
   procedure :: getSize => swigf_TeuchosComm_getSize
   procedure :: barrier => swigf_TeuchosComm_barrier
+  procedure :: getRawMpiComm => swigf_TeuchosComm_getRawMpiComm
   procedure :: release => delete_TeuchosComm
   procedure, private :: swigf_assignment_TeuchosComm
   generic :: assignment(=) => swigf_assignment_TeuchosComm
@@ -657,23 +658,6 @@ end subroutine
    type(SwigClassWrapper), intent(inout) :: self
    type(SwigClassWrapper), intent(in) :: other
   end subroutine
-function swigc_new_TeuchosComm__SWIG_0(farg1) &
-bind(C, name="swigc_new_TeuchosComm__SWIG_0") &
-result(fresult)
-use, intrinsic :: ISO_C_BINDING
-import :: SwigClassWrapper
-integer(C_INT), intent(in) :: farg1
-type(SwigClassWrapper) :: fresult
-end function
-
-function swigc_new_TeuchosComm__SWIG_1() &
-bind(C, name="swigc_new_TeuchosComm__SWIG_1") &
-result(fresult)
-use, intrinsic :: ISO_C_BINDING
-import :: SwigClassWrapper
-type(SwigClassWrapper) :: fresult
-end function
-
 function swigc_TeuchosComm_getRank(farg1) &
 bind(C, name="swigc_TeuchosComm_getRank") &
 result(fresult)
@@ -698,6 +682,32 @@ use, intrinsic :: ISO_C_BINDING
 import :: SwigClassWrapper
 type(SwigClassWrapper) :: farg1
 end subroutine
+
+function swigc_new_TeuchosComm__SWIG_0(farg1) &
+bind(C, name="swigc_new_TeuchosComm__SWIG_0") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+import :: SwigClassWrapper
+integer(C_INT), intent(in) :: farg1
+type(SwigClassWrapper) :: fresult
+end function
+
+function swigc_new_TeuchosComm__SWIG_1() &
+bind(C, name="swigc_new_TeuchosComm__SWIG_1") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+import :: SwigClassWrapper
+type(SwigClassWrapper) :: fresult
+end function
+
+function swigc_TeuchosComm_getRawMpiComm(farg1) &
+bind(C, name="swigc_TeuchosComm_getRawMpiComm") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+import :: SwigClassWrapper
+type(SwigClassWrapper) :: farg1
+integer(C_INT) :: fresult
+end function
 
 subroutine swigc_delete_TeuchosComm(farg1) &
 bind(C, name="swigc_delete_TeuchosComm")
@@ -1639,29 +1649,6 @@ end subroutine
    type(VectorLongLong), intent(in) :: other
    call swigc_assignment_VectorLongLong(self%swigdata, other%swigdata)
   end subroutine
-function new_TeuchosComm__SWIG_0(rawmpicomm) &
-result(self)
-use, intrinsic :: ISO_C_BINDING
-type(TeuchosComm) :: self
-integer(C_INT), intent(in) :: rawmpicomm
-type(SwigClassWrapper) :: fresult 
-integer(C_INT) :: farg1 
-
-farg1 = rawmpicomm
-fresult = swigc_new_TeuchosComm__SWIG_0(farg1)
-self%swigdata = fresult
-end function
-
-function new_TeuchosComm__SWIG_1() &
-result(self)
-use, intrinsic :: ISO_C_BINDING
-type(TeuchosComm) :: self
-type(SwigClassWrapper) :: fresult 
-
-fresult = swigc_new_TeuchosComm__SWIG_1()
-self%swigdata = fresult
-end function
-
 function swigf_TeuchosComm_getRank(self) &
 result(swig_result)
 use, intrinsic :: ISO_C_BINDING
@@ -1696,6 +1683,42 @@ type(SwigClassWrapper) :: farg1
 farg1 = self%swigdata
 call swigc_TeuchosComm_barrier(farg1)
 end subroutine
+
+function new_TeuchosComm__SWIG_0(rawmpicomm) &
+result(self)
+use, intrinsic :: ISO_C_BINDING
+type(TeuchosComm) :: self
+integer :: rawmpicomm
+type(SwigClassWrapper) :: fresult 
+integer(C_INT) :: farg1 
+
+farg1 = int(rawmpicomm, C_INT)
+fresult = swigc_new_TeuchosComm__SWIG_0(farg1)
+self%swigdata = fresult
+end function
+
+function new_TeuchosComm__SWIG_1() &
+result(self)
+use, intrinsic :: ISO_C_BINDING
+type(TeuchosComm) :: self
+type(SwigClassWrapper) :: fresult 
+
+fresult = swigc_new_TeuchosComm__SWIG_1()
+self%swigdata = fresult
+end function
+
+function swigf_TeuchosComm_getRawMpiComm(self) &
+result(swig_result)
+use, intrinsic :: ISO_C_BINDING
+integer :: swig_result
+class(TeuchosComm), intent(inout) :: self
+integer(C_INT) :: fresult 
+type(SwigClassWrapper) :: farg1 
+
+farg1 = self%swigdata
+fresult = swigc_TeuchosComm_getRawMpiComm(farg1)
+swig_result = int(fresult)
+end function
 
 subroutine delete_TeuchosComm(self)
 use, intrinsic :: ISO_C_BINDING

--- a/src/teuchos/src/forteuchosFORTRAN_wrap.cxx
+++ b/src/teuchos/src/forteuchosFORTRAN_wrap.cxx
@@ -578,7 +578,7 @@ SWIGINTERN std::vector< long long >::value_type std_vector_Sl_long_SS_long_Sg__g
 
 SWIGINTERN Teuchos::Comm< int > *new_Teuchos_Comm_Sl_int_Sg___SWIG_0(MPI_Comm rawMpiComm){
 #ifdef HAVE_MPI
-      return static_cast<Teuchos::Comm<int>*>(new Teuchos::MpiComm<int>(rawMpiComm));
+      return new Teuchos::MpiComm<int>(rawMpiComm);
 #else
       throw std::runtime_error("MPI based constructor cannot be called when MPI is not enabled.");
 #endif
@@ -591,19 +591,18 @@ SWIGINTERN Teuchos::Comm< int > *new_Teuchos_Comm_Sl_int_Sg___SWIG_0(MPI_Comm ra
 
 SWIGINTERN Teuchos::Comm< int > *new_Teuchos_Comm_Sl_int_Sg___SWIG_1(){
 #ifdef HAVE_MPI
-      return static_cast<Teuchos::Comm<int>*>(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
+      return new Teuchos::MpiComm<int>(MPI_COMM_WORLD);
 #else
-      return static_cast<Teuchos::Comm<int>*>(new Teuchos::SerialComm<int>());
+      return new Teuchos::SerialComm<int>();
 #endif
     }
-SWIGINTERN int Teuchos_Comm_Sl_int_Sg__getRank(Teuchos::Comm< int > const *self){
-      return self->getRank();
-    }
-SWIGINTERN int Teuchos_Comm_Sl_int_Sg__getSize(Teuchos::Comm< int > const *self){
-      return self->getSize();
-    }
-SWIGINTERN void Teuchos_Comm_Sl_int_Sg__barrier(Teuchos::Comm< int > const *self){
-      self->barrier();
+SWIGINTERN MPI_Comm Teuchos_Comm_Sl_int_Sg__getRawMpiComm(Teuchos::Comm< int > *self){
+#ifdef HAVE_MPI
+      Teuchos::MpiComm<int>& comm = dynamic_cast<Teuchos::MpiComm<int>&>(*self);
+      return *comm.getRawMpiComm();
+#else
+      throw std::runtime_error("MPI based constructor cannot be called when MPI is not enabled.");
+#endif
     }
 
 #include "Teuchos_ParameterList.hpp"
@@ -1341,18 +1340,121 @@ SWIGEXPORT void swigc_assignment_VectorLongLong(SwigClassWrapper * self, SwigCla
 }
 
 
+SWIGEXPORT int swigc_TeuchosComm_getRank(SwigClassWrapper const *farg1) {
+  int fresult ;
+  Teuchos::Comm< int > *arg1 = (Teuchos::Comm< int > *) 0 ;
+  Teuchos::RCP< Teuchos::Comm< int > const > *smartarg1 ;
+  int result;
+  
+  smartarg1 = static_cast< Teuchos::RCP<const Teuchos::Comm<int> >* >(farg1->ptr);
+  arg1 = smartarg1 ? const_cast<Teuchos::Comm<int>*>(smartarg1->get()) : NULL;
+  {
+    // Make sure no unhandled exceptions exist before performing a new action
+    SWIG_check_unhandled_exception_impl("Teuchos::Comm< int >::getRank() const");;
+    try
+    {
+      // Attempt the wrapped function call
+      result = (int)((Teuchos::Comm< int > const *)arg1)->getRank();
+    }
+    catch (const std::range_error& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("Teuchos::Comm< int >::getRank() const", SWIG_IndexError, e.what(), return 0);
+    }
+    catch (const std::exception& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("Teuchos::Comm< int >::getRank() const", SWIG_RuntimeError, e.what(), return 0);
+    }
+    catch (...)
+    {
+      SWIG_exception_impl("Teuchos::Comm< int >::getRank() const", SWIG_UnknownError, "An unknown exception occurred", return 0);
+    }
+  }
+  fresult = result;
+  return fresult;
+}
+
+
+SWIGEXPORT int swigc_TeuchosComm_getSize(SwigClassWrapper const *farg1) {
+  int fresult ;
+  Teuchos::Comm< int > *arg1 = (Teuchos::Comm< int > *) 0 ;
+  Teuchos::RCP< Teuchos::Comm< int > const > *smartarg1 ;
+  int result;
+  
+  smartarg1 = static_cast< Teuchos::RCP<const Teuchos::Comm<int> >* >(farg1->ptr);
+  arg1 = smartarg1 ? const_cast<Teuchos::Comm<int>*>(smartarg1->get()) : NULL;
+  {
+    // Make sure no unhandled exceptions exist before performing a new action
+    SWIG_check_unhandled_exception_impl("Teuchos::Comm< int >::getSize() const");;
+    try
+    {
+      // Attempt the wrapped function call
+      result = (int)((Teuchos::Comm< int > const *)arg1)->getSize();
+    }
+    catch (const std::range_error& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("Teuchos::Comm< int >::getSize() const", SWIG_IndexError, e.what(), return 0);
+    }
+    catch (const std::exception& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("Teuchos::Comm< int >::getSize() const", SWIG_RuntimeError, e.what(), return 0);
+    }
+    catch (...)
+    {
+      SWIG_exception_impl("Teuchos::Comm< int >::getSize() const", SWIG_UnknownError, "An unknown exception occurred", return 0);
+    }
+  }
+  fresult = result;
+  return fresult;
+}
+
+
+SWIGEXPORT void swigc_TeuchosComm_barrier(SwigClassWrapper const *farg1) {
+  Teuchos::Comm< int > *arg1 = (Teuchos::Comm< int > *) 0 ;
+  Teuchos::RCP< Teuchos::Comm< int > const > *smartarg1 ;
+  
+  smartarg1 = static_cast< Teuchos::RCP<const Teuchos::Comm<int> >* >(farg1->ptr);
+  arg1 = smartarg1 ? const_cast<Teuchos::Comm<int>*>(smartarg1->get()) : NULL;
+  {
+    // Make sure no unhandled exceptions exist before performing a new action
+    SWIG_check_unhandled_exception_impl("Teuchos::Comm< int >::barrier() const");;
+    try
+    {
+      // Attempt the wrapped function call
+      ((Teuchos::Comm< int > const *)arg1)->barrier();
+    }
+    catch (const std::range_error& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("Teuchos::Comm< int >::barrier() const", SWIG_IndexError, e.what(), return );
+    }
+    catch (const std::exception& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("Teuchos::Comm< int >::barrier() const", SWIG_RuntimeError, e.what(), return );
+    }
+    catch (...)
+    {
+      SWIG_exception_impl("Teuchos::Comm< int >::barrier() const", SWIG_UnknownError, "An unknown exception occurred", return );
+    }
+  }
+  
+}
+
+
 SWIGEXPORT SwigClassWrapper swigc_new_TeuchosComm__SWIG_0(int const *farg1) {
   SwigClassWrapper fresult ;
   MPI_Comm arg1 ;
   Teuchos::Comm< int > *result = 0 ;
   
-  
 #ifdef HAVE_MPI
-  arg1 = (MPI_Comm)(MPI_Comm_f2c(*(MPI_Fint *)(farg1)));
+  arg1 = MPI_Comm_f2c(static_cast< MPI_Fint >(*farg1));
 #else
   arg1 = *farg1;
 #endif
-  
   {
     // Make sure no unhandled exceptions exist before performing a new action
     SWIG_check_unhandled_exception_impl("Teuchos::Comm< int >::Comm(MPI_Comm)");;
@@ -1415,108 +1517,43 @@ SWIGEXPORT SwigClassWrapper swigc_new_TeuchosComm__SWIG_1() {
 }
 
 
-SWIGEXPORT int swigc_TeuchosComm_getRank(SwigClassWrapper const *farg1) {
+SWIGEXPORT int swigc_TeuchosComm_getRawMpiComm(SwigClassWrapper const *farg1) {
   int fresult ;
   Teuchos::Comm< int > *arg1 = (Teuchos::Comm< int > *) 0 ;
-  Teuchos::RCP< Teuchos::Comm< int > const > *smartarg1 ;
-  int result;
+  Teuchos::RCP< Teuchos::Comm< int > > *smartarg1 ;
+  MPI_Comm result;
   
-  smartarg1 = static_cast< Teuchos::RCP<const Teuchos::Comm<int> >* >(farg1->ptr);
-  arg1 = smartarg1 ? const_cast<Teuchos::Comm<int>*>(smartarg1->get()) : NULL;
+  smartarg1 = static_cast< Teuchos::RCP< Teuchos::Comm<int> >* >(farg1->ptr);
+  arg1 = smartarg1 ? smartarg1->get() : NULL;
   {
     // Make sure no unhandled exceptions exist before performing a new action
-    SWIG_check_unhandled_exception_impl("Teuchos::Comm< int >::getRank() const");;
+    SWIG_check_unhandled_exception_impl("Teuchos::Comm< int >::getRawMpiComm()");;
     try
     {
       // Attempt the wrapped function call
-      result = (int)Teuchos_Comm_Sl_int_Sg__getRank((Teuchos::Comm< int > const *)arg1);
+      result = Teuchos_Comm_Sl_int_Sg__getRawMpiComm(arg1);
     }
     catch (const std::range_error& e)
     {
       // Store a C++ exception
-      SWIG_exception_impl("Teuchos::Comm< int >::getRank() const", SWIG_IndexError, e.what(), return 0);
+      SWIG_exception_impl("Teuchos::Comm< int >::getRawMpiComm()", SWIG_IndexError, e.what(), return 0);
     }
     catch (const std::exception& e)
     {
       // Store a C++ exception
-      SWIG_exception_impl("Teuchos::Comm< int >::getRank() const", SWIG_RuntimeError, e.what(), return 0);
+      SWIG_exception_impl("Teuchos::Comm< int >::getRawMpiComm()", SWIG_RuntimeError, e.what(), return 0);
     }
     catch (...)
     {
-      SWIG_exception_impl("Teuchos::Comm< int >::getRank() const", SWIG_UnknownError, "An unknown exception occurred", return 0);
+      SWIG_exception_impl("Teuchos::Comm< int >::getRawMpiComm()", SWIG_UnknownError, "An unknown exception occurred", return 0);
     }
   }
-  fresult = result;
+#ifdef HAVE_MPI
+  fresult = static_cast< int >(MPI_Comm_c2f(result));
+#else
+  result = *$input;
+#endif
   return fresult;
-}
-
-
-SWIGEXPORT int swigc_TeuchosComm_getSize(SwigClassWrapper const *farg1) {
-  int fresult ;
-  Teuchos::Comm< int > *arg1 = (Teuchos::Comm< int > *) 0 ;
-  Teuchos::RCP< Teuchos::Comm< int > const > *smartarg1 ;
-  int result;
-  
-  smartarg1 = static_cast< Teuchos::RCP<const Teuchos::Comm<int> >* >(farg1->ptr);
-  arg1 = smartarg1 ? const_cast<Teuchos::Comm<int>*>(smartarg1->get()) : NULL;
-  {
-    // Make sure no unhandled exceptions exist before performing a new action
-    SWIG_check_unhandled_exception_impl("Teuchos::Comm< int >::getSize() const");;
-    try
-    {
-      // Attempt the wrapped function call
-      result = (int)Teuchos_Comm_Sl_int_Sg__getSize((Teuchos::Comm< int > const *)arg1);
-    }
-    catch (const std::range_error& e)
-    {
-      // Store a C++ exception
-      SWIG_exception_impl("Teuchos::Comm< int >::getSize() const", SWIG_IndexError, e.what(), return 0);
-    }
-    catch (const std::exception& e)
-    {
-      // Store a C++ exception
-      SWIG_exception_impl("Teuchos::Comm< int >::getSize() const", SWIG_RuntimeError, e.what(), return 0);
-    }
-    catch (...)
-    {
-      SWIG_exception_impl("Teuchos::Comm< int >::getSize() const", SWIG_UnknownError, "An unknown exception occurred", return 0);
-    }
-  }
-  fresult = result;
-  return fresult;
-}
-
-
-SWIGEXPORT void swigc_TeuchosComm_barrier(SwigClassWrapper const *farg1) {
-  Teuchos::Comm< int > *arg1 = (Teuchos::Comm< int > *) 0 ;
-  Teuchos::RCP< Teuchos::Comm< int > const > *smartarg1 ;
-  
-  smartarg1 = static_cast< Teuchos::RCP<const Teuchos::Comm<int> >* >(farg1->ptr);
-  arg1 = smartarg1 ? const_cast<Teuchos::Comm<int>*>(smartarg1->get()) : NULL;
-  {
-    // Make sure no unhandled exceptions exist before performing a new action
-    SWIG_check_unhandled_exception_impl("Teuchos::Comm< int >::barrier() const");;
-    try
-    {
-      // Attempt the wrapped function call
-      Teuchos_Comm_Sl_int_Sg__barrier((Teuchos::Comm< int > const *)arg1);
-    }
-    catch (const std::range_error& e)
-    {
-      // Store a C++ exception
-      SWIG_exception_impl("Teuchos::Comm< int >::barrier() const", SWIG_IndexError, e.what(), return );
-    }
-    catch (const std::exception& e)
-    {
-      // Store a C++ exception
-      SWIG_exception_impl("Teuchos::Comm< int >::barrier() const", SWIG_RuntimeError, e.what(), return );
-    }
-    catch (...)
-    {
-      SWIG_exception_impl("Teuchos::Comm< int >::barrier() const", SWIG_UnknownError, "An unknown exception occurred", return );
-    }
-  }
-  
 }
 
 

--- a/src/teuchos/src/forteuchosFORTRAN_wrap.cxx
+++ b/src/teuchos/src/forteuchosFORTRAN_wrap.cxx
@@ -1551,7 +1551,7 @@ SWIGEXPORT int swigc_TeuchosComm_getRawMpiComm(SwigClassWrapper const *farg1) {
 #ifdef HAVE_MPI
   fresult = static_cast< int >(MPI_Comm_c2f(result));
 #else
-  result = *$input;
+  fresult = result;
 #endif
   return fresult;
 }

--- a/src/teuchos/test/test_teuchos_comm.f90
+++ b/src/teuchos/test/test_teuchos_comm.f90
@@ -56,7 +56,7 @@ contains
     TEST_EQUALITY(MPI_COMM_WORLD, mpicomm)
 #else
     ! Should have thrown an error
-    FORTEST_INEQUALITY(0, fortrilinos_ierr)
+    TEST_INEQUALITY(0, fortrilinos_ierr)
     FORTRILINOS_IERR = 0
 #endif
 

--- a/src/teuchos/test/test_teuchos_comm.f90
+++ b/src/teuchos/test/test_teuchos_comm.f90
@@ -16,7 +16,7 @@ program test_TeuchosComm
 
   implicit none
   character(len=26), parameter :: FILENAME='test_teuchos_comm.f90'
-  integer :: ierr
+  integer :: ierr, mpicomm
 
 
   SETUP_TEST()
@@ -50,6 +50,15 @@ contains
 
     comm_size_c = comm%getSize(); TEST_IERR()
     TEST_EQUALITY(comm_size_f, comm_size_c)
+
+    mpicomm = comm%getRawMpiComm()
+#ifdef HAVE_MPI
+    TEST_EQUALITY(MPI_COMM_WORLD, mpicomm)
+#else
+    ! Should have thrown an error
+    FORTEST_INEQUALITY(0, fortrilinos_ierr)
+    FORTRILINOS_IERR = 0
+#endif
 
     call comm%release()
 


### PR DESCRIPTION
- Simplify/improve typemap from the one I originally wrote
- Use ISO C compatibility layer for C/F type, and MPI types elsewhere
- Add MPI-fortran output of comm handle