### PR TITLE
WIP: Upgrade ForTrilinos and enable TpetraOperator derived type

### DIFF
--- a/src/teuchos/src/Teuchos_ArrayRCP.i
+++ b/src/teuchos/src/Teuchos_ArrayRCP.i
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017, UT-Battelle, LLC
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * License-Filename: LICENSE
+ */
+%{
+#include "Teuchos_ArrayRCP.hpp"
+%}
+
+%include <view.i>
+
+namespace Teuchos
+{
+template<typename T>
+class ArrayRCP
+{
+  public:
+    typedef T value_type;
+    typedef std::size_t size_type;
+};
+}
+
+// Create RCP with no-ownership flag (it's set to false)
+%define TEUCHOS_ARRAYRCP_IMPL(CONST, CTYPE)
+  // Treat const references as values
+  %apply Teuchos::ArrayRCP<CONST CTYPE> { const Teuchos::ArrayRCP<CONST CTYPE>& }
+
+  // C input translation typemaps: $1 is ArrayRCP, $input is SwigArrayWrapper
+  %typemap(in) Teuchos::ArrayRCP<CONST CTYPE> %{
+    $1 = Teuchos::ArrayRCP(static_cast<CONST CTYPE*>($input->data), 0, $input->size, false);
+  %}
+  %typemap(in) const Teuchos::ArrayRCP<CONST CTYPE>& (Teuchos::ArrayRCP<CONST CTYPE> temprcp) %{
+    temprcp = Teuchos::ArrayRCP(static_cast<CONST CTYPE*>($input->data), 0, $input->size, false);
+    $1 = &temprcp;
+  %}
+
+  %template() Teuchos::ArrayRCP<CONST CTYPE>;
+%enddef
+
+/* -------------------------------------------------------------------------
+ * \def %TEUCHOS_ARRAYRCP
+ *
+ * This maps a return value of ArrayRCP to a small struct (mirrored in
+ * fortran) that defines the start and size of a contiguous array.
+ */
+%define TEUCHOS_ARRAYRCP(CTYPE)
+  // Use SwigArrayWrapper and array pointer translation for this type
+  FORT_ARRAYPTR_TYPEMAP(CTYPE, Teuchos::ArrayRCP<CTYPE>)
+  %apply Teuchos::ArrayRCP<CTYPE> { Teuchos::ArrayRCP<const CTYPE> }
+
+  // Use pointer translation for const variables too
+  TEUCHOS_ARRAYRCP_IMPL(, CTYPE)
+  TEUCHOS_ARRAYRCP_IMPL(const, CTYPE)
+
+  %typemap(out) Teuchos::ArrayRCP<const CTYPE> %{
+    $result.data = const_cast<CTYPE*>($1.getRawPtr());
+    $result.size = $1.size();
+  %}
+%enddef
+
+TEUCHOS_ARRAYRCP(int);
+TEUCHOS_ARRAYRCP(double);
+TEUCHOS_ARRAYRCP(long long);
+TEUCHOS_ARRAYRCP(size_t);
+

--- a/src/teuchos/src/Teuchos_ArrayView.i
+++ b/src/teuchos/src/Teuchos_ArrayView.i
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017, UT-Battelle, LLC
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * License-Filename: LICENSE
+ */
+%{
+#include "Teuchos_ArrayView.hpp"
+%}
+
+%include <view.i>
+
+namespace Teuchos
+{
+template<typename T>
+class ArrayView
+{
+  public:
+    typedef T value_type;
+    typedef std::size_t size_type;
+};
+}
+
+%define TEUCHOS_ARRAYVIEW_IMPL(CONST, CTYPE)
+  // Treat const references as values
+  %apply Teuchos::ArrayView<CONST CTYPE> { const Teuchos::ArrayView<CONST CTYPE>& }
+
+  // C input translation typemaps: $1 is ArrayView, $input is SwigArrayWrapper
+  %typemap(in) Teuchos::ArrayView<CONST CTYPE> %{
+    $1 = Teuchos::arrayView(static_cast<CONST CTYPE*>($input->data), $input->size);
+  %}
+  %typemap(in) const Teuchos::ArrayView<CONST CTYPE>& (Teuchos::ArrayView<CONST CTYPE> tempview) %{
+    tempview = Teuchos::arrayView(static_cast<CONST CTYPE*>($input->data), $input->size);
+    $1 = &tempview;
+  %}
+
+  %template() Teuchos::ArrayView<CONST CTYPE>;
+%enddef
+
+/* -------------------------------------------------------------------------
+ * \def %TEUCHOS_ARRAYVIEW
+ *
+ * This maps a return value of ArrayView to a small struct (mirrored in
+ * fortran) that defines the start and size of a contiguous array.
+ */
+%define TEUCHOS_ARRAYVIEW(CTYPE)
+  // Use SwigArrayWrapper and array pointer translation for this type
+  FORT_ARRAYPTR_TYPEMAP(CTYPE, Teuchos::ArrayView<CTYPE>)
+  %apply Teuchos::ArrayView<CTYPE> { Teuchos::ArrayView<const CTYPE> }
+
+  // Use pointer translation for const variables too
+  TEUCHOS_ARRAYVIEW_IMPL(, CTYPE)
+  TEUCHOS_ARRAYVIEW_IMPL(const, CTYPE)
+
+  %typemap(out) Teuchos::ArrayView<const CTYPE> %{
+    $result.data = const_cast<CTYPE*>($1.getRawPtr());
+    $result.size = $1.size();
+  %}
+%enddef
+
+TEUCHOS_ARRAYVIEW(int);
+TEUCHOS_ARRAYVIEW(double);
+TEUCHOS_ARRAYVIEW(long long);
+

--- a/src/teuchos/src/Teuchos_ArrayView.i
+++ b/src/teuchos/src/Teuchos_ArrayView.i
@@ -62,3 +62,28 @@ TEUCHOS_ARRAYVIEW(int);
 TEUCHOS_ARRAYVIEW(double);
 TEUCHOS_ARRAYVIEW(long long);
 
+
+/* -------------------------------------------------------------------------
+ * Typemaps: convert to/from Fortran indexing.
+ */
+%typemap(in, noblock=1) Teuchos::ArrayView<int> FORTRAN_INDEX
+    (Teuchos::Array<$1_ltype::value_type > tmparr,
+     Teuchos::ArrayView<$1_ltype::value_type > tmpview) {
+  tmparr.resize($1->size());
+
+  for (int i = 0; i < $1->size(); i++)
+    (*$1)[i] = (static_cast<$1_ltype::value_type*>($input))[i] - 1;
+  tmpview = tmparr
+  $1 = &tmpview;
+}
+
+%typemap(argout, noblock=1) Teuchos::ArrayView<int> FORTRAN_INDEX {
+  for (int i = 0; i < $1->size(); i++)
+    (*$1)[i]++;
+}
+
+// Convert a return-by-view array in C indexing to Fortran indexing.
+%typemap(argout, noblock=1) Teuchos::ArrayView<int> FORTRAN_INDEX {
+  for (int i = 0; i < $1->size(); i++)
+    (*$1)[i]++;
+}

--- a/src/teuchos/src/Teuchos_ArrayView.i
+++ b/src/teuchos/src/Teuchos_ArrayView.i
@@ -61,6 +61,7 @@ class ArrayView
 TEUCHOS_ARRAYVIEW(int);
 TEUCHOS_ARRAYVIEW(double);
 TEUCHOS_ARRAYVIEW(long long);
+TEUCHOS_ARRAYVIEW(size_t);
 
 
 /* -------------------------------------------------------------------------

--- a/src/teuchos/src/forteuchos.i
+++ b/src/teuchos/src/forteuchos.i
@@ -44,6 +44,7 @@ namespace Teuchos {
 %include "Teuchos_RCP.i"
 
 %include "Teuchos_Array.i"
+%include "Teuchos_ArrayView.i"
 %include "Teuchos_Comm.i"
 %include "Teuchos_ParameterList.i"
 %include "Teuchos_XML.i"

--- a/src/teuchos/src/forteuchos.i
+++ b/src/teuchos/src/forteuchos.i
@@ -48,3 +48,8 @@ namespace Teuchos {
 %include "Teuchos_Comm.i"
 %include "Teuchos_ParameterList.i"
 %include "Teuchos_XML.i"
+
+// Declare typemaps that translate from C to Fortran indexing
+%typemap(in)    int FORTRAN_INDEX %{$1 = *$input - 1;%}
+%typemap(out)   int FORTRAN_INDEX %{$result = $1 + 1;%}
+

--- a/src/teuchos/src/forteuchos.i
+++ b/src/teuchos/src/forteuchos.i
@@ -45,6 +45,7 @@ namespace Teuchos {
 
 %include "Teuchos_Array.i"
 %include "Teuchos_ArrayView.i"
+%include "Teuchos_ArrayRCP.i"
 %include "Teuchos_Comm.i"
 %include "Teuchos_ParameterList.i"
 %include "Teuchos_XML.i"

--- a/src/teuchos/src/forteuchosFORTRAN_wrap.cxx
+++ b/src/teuchos/src/forteuchosFORTRAN_wrap.cxx
@@ -274,6 +274,9 @@ struct assignment_flags<std::pair<T, const U>, Flags> {
 #include "Teuchos_Array.hpp"
 
 
+#include "Teuchos_ArrayView.hpp"
+
+
 #include "Teuchos_Comm.hpp"
 #ifdef HAVE_MPI
 # include "Teuchos_DefaultMpiComm.hpp"

--- a/src/teuchos/src/forteuchosFORTRAN_wrap.cxx
+++ b/src/teuchos/src/forteuchosFORTRAN_wrap.cxx
@@ -277,6 +277,9 @@ struct assignment_flags<std::pair<T, const U>, Flags> {
 #include "Teuchos_ArrayView.hpp"
 
 
+#include "Teuchos_ArrayRCP.hpp"
+
+
 #include "Teuchos_Comm.hpp"
 #ifdef HAVE_MPI
 # include "Teuchos_DefaultMpiComm.hpp"

--- a/src/tpetra/src/Tpetra_CrsGraph.i
+++ b/src/tpetra/src/Tpetra_CrsGraph.i
@@ -63,25 +63,10 @@
 // =======================================================================
 // Fix ±1 issues
 // =======================================================================
-%typemap(in)  int localRow %{$1 = *$input - 1;%}
-%typemap(argout) const Teuchos::ArrayView< int > &indices %{
-  for (int i = 0; i < $1->size(); i++)
-    (*$1)[i]++;
-%}
-%typemap(in, noblock=1) const Teuchos::ArrayView< int > &indices () {
-
-  // Original typemap: convert void* to thinvec reference
-  $1 = %static_cast(%const_cast($input, void*), $1_ltype);
-
-  // Construct temporary array and view
-  Teuchos::Array<int> tmp = Teuchos::Array<int>($1->size());
-  for (int i = 0; i < $1->size(); i++)
-    tmp[i] = (*$1)[i] - 1;
-  Teuchos::ArrayView<int> tmpview = tmp();
-
-  // Make the input argument point to our temporary vector
-  $1 = &tmpview;
-}
+%apply int FORTRAN_INDEX { int localRow };
+%apply Teuchos::ArrayView<int> FORTRAN_INDEX {
+    const Teuchos::ArrayView<int> &indices
+};
 
 // =======================================================================
 // Make interface more Fortran friendly

--- a/src/tpetra/src/Tpetra_Map.i
+++ b/src/tpetra/src/Tpetra_Map.i
@@ -36,20 +36,6 @@
 
 // =======================================================================
 // Fix ±1 issues
-// =======================================================================
-%typemap(in)  int localIndex        %{$1 = *$input - 1;%}
-%typemap(out) int getMinLocalIndex  %{$result = $1 + 1;%}
-%typemap(out) int getMaxLocalIndex  %{$result = $1 + 1;%}
-%typemap(out) int getLocalElement   %{$result = $1 + 1;%}
-%typemap(argout) const Teuchos::ArrayView<int>& nodeIDList %{
-  for (int i = 0; i < $1->size(); i++)
-    (*$1)[i]++;
-%}
-%typemap(argout) const Teuchos::ArrayView<int>& LIDList %{
-  for (int i = 0; i < $1->size(); i++)
-    (*$1)[i]++;
-%}
-
 
 // =======================================================================
 // Make interface more Fortran friendly
@@ -89,6 +75,19 @@
 %ignore Tpetra::Map::getRemoteIndexList (const Teuchos::ArrayView< const GlobalOrdinal > &GIDList, const Teuchos::ArrayView< int > &nodeIDList, const Teuchos::ArrayView< LocalOrdinal > &LIDList) const;
 %ignore Tpetra::Map::getRemoteIndexList (const Teuchos::ArrayView< const GlobalOrdinal > &GIDList, const Teuchos::ArrayView< int > &nodeIDList) const;
 %ignore Tpetra::Map::getNodeElementList() const;
+//
+// (see forteuchos.i)
+// =======================================================================
+%apply int FORTRAN_INDEX { int localIndex,
+                           int getMinLocalIndex,
+                           int getMaxLocalIndex,
+                           int getLocalElement };
+
+// Note: these are modifying fortran-owned memory, decrementing the count after
+// the values have been retrieved.
+%apply Teuchos::ArrayView<int> FORTRAN_INDEX {
+    const Teuchos::ArrayView<int>& nodeIDList,
+    const Teuchos::ArrayView<int>& LIDList };
 
 %include "Tpetra_Map_decl.hpp"
 

--- a/src/tpetra/src/Tpetra_MultiVector.i
+++ b/src/tpetra/src/Tpetra_MultiVector.i
@@ -55,9 +55,12 @@
 // =======================================================================
 // Fix ±1 issues
 // =======================================================================
-%typemap(in)  size_t j %{$1 = *$input - 1;%}
-%typemap(in)  size_t col %{$1 = *$input - 1;%}
-%typemap(in)  int lclRow %{$1 = *$input - 1;%} /* int = LocalOrdinal */
+
+%apply int FORTRAN_INDEX { size_t j,
+                           size_t col,
+                           int lclRow };
+
+%apply Teuchos::ArrayView<int> FORTRAN_INDEX { Teuchos::ArrayView<const size_t> cols };
 
 // =======================================================================
 // Make interface more Fortran friendly

--- a/src/tpetra/src/Tpetra_Operator.i
+++ b/src/tpetra/src/Tpetra_Operator.i
@@ -6,24 +6,172 @@
  */
 
 // Dependencies
-%include "Teuchos_RCP.i"
-%import <std_string.i>
 %import <Teuchos_Comm.i>
+%import <Tpetra_MultiVector.i>
 
 %{
-#include "Teuchos_RCP.hpp"
 #include "Tpetra_Operator.hpp"
 %}
 
 // =======================================================================
-// Ignore permanently
-// =======================================================================
-
-// =======================================================================
-// Postpone temporarily
+// Instantiate the Operator
 // =======================================================================
 
 %include "Tpetra_Operator.hpp"
 
 %teuchos_rcp(Tpetra::Operator<SC,LO,GO,NO>)
-%template(TpetraOperator) Tpetra::Operator<SC,LO,GO,NO>;
+%template() Tpetra::Operator<SC,LO,GO,NO>;
+
+// =======================================================================
+// Add the subclass
+// =======================================================================
+
+%teuchos_rcp(TpetraOperator)
+
+%insert("header") %{
+extern "C" {
+/* Fortran BIND(C) function */
+SwigArrayWrapper swigd_TpetraOperator_apply(
+        SwigClassWrapper const *fself,
+        SwigClassWrapper const *farg1,
+        SwigClassWrapper const *farg2,
+        int *farg3,
+        double const *farg4,
+        double const *farg5
+        );
+}
+%}
+
+%fortranprepend TpetraOperator::~TpetraOperator() %{
+  type(C_PTR) :: fself_ptr
+  type(TpetraOperatorWrapper), pointer :: handle
+  fself_ptr = swigc_TpetraOperator_fhandle(self%swigdata)
+  call c_f_pointer(cptr=fself_ptr, fptr=handle)
+%}
+
+%fortranappend TpetraOperator::~TpetraOperator() %{
+  ! Release the allocated handle
+  deallocate(handle)
+%}
+
+%inline %{
+  class TpetraOperator : public Tpetra::Operator<SC,LO,GO,NO> {
+    // Pointer to polymorphic fortran pointer
+    void* fhandle_;
+   public:
+    /* DIRECTOR FUNCTIONS */
+    const void* fhandle() const { return this->fhandle_; }
+    void init(void* fh) { fhandle_ = fh; }
+
+    /* TPETRA */
+    typedef Tpetra::MultiVector<SC,LO,GO,NO> MV_type;
+    typedef Tpetra::Map<LO,GO,NO> Map_type;
+    TpetraOperator() : fhandle_(NULL) { /* * */ }
+
+
+    virtual Teuchos::RCP<const Map_type> getDomainMap() const { return Teuchos::null; }
+    virtual Teuchos::RCP<const Map_type> getRangeMap() const { return Teuchos::null; }
+
+    virtual void apply(const MV_type &X, MV_type &Y,
+                       Teuchos::ETransp mode, SC alpha, SC beta) const
+    {
+      /* construct "this" pointer */
+      SwigClassWrapper self;
+      self.ptr = const_cast<TpetraOperator*>(this);
+      self.mem = SWIG_CREF; // since this function is const
+
+      /* convert X -> class wrapper */
+      Teuchos::RCP<const Tpetra::MultiVector<SC,LO,GO,NO> > temprcp1(&X SWIG_NO_NULL_DELETER_0);
+
+      SwigClassWrapper farg1;
+      farg1.ptr = &temprcp1;
+      farg1.mem = SWIG_CREF; // X is const
+
+      Teuchos::RCP< Tpetra::MultiVector<SC,LO,GO,NO> > temprcp2(&Y SWIG_NO_NULL_DELETER_0);
+
+      SwigClassWrapper farg2;
+      farg2.ptr = &temprcp2;
+      farg2.mem = SWIG_REF; // Y is mutable
+
+      /* convert scalars to wrappers */
+      int farg3 = mode;
+      double farg4 = alpha;
+      double farg5 = beta;
+
+      swigd_TpetraOperator_apply(&self, &farg1, &farg2, &farg3, &farg4, &farg5);
+    }
+  };
+%}
+
+%insert("ftypes") %{
+  type :: TpetraOperatorWrapper
+    class(TpetraOperator), pointer :: data
+  end type
+%}
+
+%insert("fpublic") %{
+public :: init_TpetraOperator
+%}
+
+%insert("fwrapper") %{
+! Convert a ISO-C class pointer struct into a user Fortran native pointer
+subroutine c_f_pointer_TpetraOperator(clswrap, fptr)
+  type(SwigClassWrapper), intent(in) :: clswrap
+  class(TpetraOperator), pointer, intent(out) :: fptr
+  type(TpetraOperatorWrapper), pointer :: handle
+  type(C_PTR) :: fself_ptr
+  ! Convert C handle to fortran pointer
+  fself_ptr = swigc_TpetraOperator_fhandle(clswrap)
+  ! *** NOTE *** : gfortran 5 through 7 falsely claim the next line is not standards compliant. Since 'handle' is a scalar and
+  ! not an array it should be OK, but TS29113 explicitly removes the interoperability requirement for fptr.
+  ! Error: TS 29113/TS 18508: Noninteroperable array FPTR at (1) to C_F_POINTER: Expression is a noninteroperable derived type
+  ! see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84924
+  call c_f_pointer(cptr=fself_ptr, fptr=handle)
+  ! Access the pointer inside that
+  fptr => handle%data
+end subroutine
+
+! Convert SWIG array wrapper to temporary Fortran string, pass to the fortran
+! cb function, convert back to SWIG array wrapper.
+! This function must have input/output arguments compatible with ISO C, and it must be marked with "bind(C)"
+subroutine swigd_TpetraOperator_apply(fself, farg1, farg2, farg3, farg4, farg5) &
+    bind(C, name="swigd_TpetraOperator_apply")
+  use, intrinsic :: ISO_C_BINDING
+  implicit none
+  type(SwigClassWrapper), intent(in) :: fself
+  type(SwigClassWrapper), intent(in) :: farg1
+  type(SwigClassWrapper), intent(in) :: farg2
+  integer(C_INT), intent(in) :: farg3
+  real(C_DOUBLE), intent(in) :: farg4
+  real(C_DOUBLE), intent(in) :: farg5
+
+  class(TpetraOperator), pointer :: self
+  type(TpetraMultiVector) :: x
+  type(TpetraMultiVector) :: y
+  integer(kind(TeuchosETransp)) :: mode
+  real(C_DOUBLE) :: alpha
+  real(C_DOUBLE) :: beta
+
+  ! Get pointer to Fortran object from class wrapper
+  call c_f_pointer_TpetraOperator(fself, self)
+  ! Convert class references to fortran proxy references
+  x%swigdata = farg1
+  y%swigdata = farg2
+  ! Copy scalars
+  mode  = int(farg3, kind(TeuchosETransp))
+  alpha = farg4
+  beta  = farg5
+  ! Call fortran function pointer with native fortran input/output
+  call self%apply(x, y, mode, alpha, beta)
+end subroutine
+
+subroutine init_TpetraOperator(self)
+  class(TpetraOperator), target :: self
+  type(TpetraOperatorWrapper), pointer :: handle
+  allocate(handle)
+  handle%data => self
+  self%swigdata = swigc_new_TpetraOperator()
+  call swigc_TpetraOperator_init(self%swigdata, c_loc(handle))
+end subroutine
+%}
+

--- a/src/tpetra/src/fortpetra.f90
+++ b/src/tpetra/src/fortpetra.f90
@@ -79,6 +79,10 @@ end type
  public :: TpetraExport
  public :: TpetraImport
  public :: TpetraMultiVector
+ public :: TpetraOperator
+
+public :: init_TpetraOperator
+
  public :: RowInfo
  public :: TpetraELocalGlobal, TpetraLocalIndices, TpetraGlobalIndices
  public :: TpetraCrsGraph
@@ -304,6 +308,27 @@ end type
   procedure new_TpetraMultiVector__SWIG_6
   procedure new_TpetraMultiVector__SWIG_7
  end interface
+ type :: TpetraOperator
+  ! These should be treated as PROTECTED data
+  type(SwigClassWrapper), public :: swigdata
+ contains
+  procedure :: fhandle => swigf_TpetraOperator_fhandle
+  procedure :: init => swigf_TpetraOperator_init
+  procedure :: getDomainMap => swigf_TpetraOperator_getDomainMap
+  procedure :: getRangeMap => swigf_TpetraOperator_getRangeMap
+  procedure :: apply => swigf_TpetraOperator_apply
+  procedure :: release => delete_TpetraOperator
+  procedure, private :: swigf_assignment_TpetraOperator
+  generic :: assignment(=) => swigf_assignment_TpetraOperator
+ end type TpetraOperator
+ interface TpetraOperator
+  procedure new_TpetraOperator
+ end interface
+
+  type :: TpetraOperatorWrapper
+    class(TpetraOperator), pointer :: data
+  end type
+
  type :: RowInfo
   ! These should be treated as PROTECTED data
   type(SwigClassWrapper), public :: swigdata
@@ -1770,6 +1795,75 @@ end subroutine
 
   subroutine swigc_assignment_TpetraMultiVector(self, other) &
      bind(C, name="swigc_assignment_TpetraMultiVector")
+   use, intrinsic :: ISO_C_BINDING
+   import :: SwigClassWrapper
+   type(SwigClassWrapper), intent(inout) :: self
+   type(SwigClassWrapper), intent(in) :: other
+  end subroutine
+function swigc_TpetraOperator_fhandle(farg1) &
+bind(C, name="swigc_TpetraOperator_fhandle") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+import :: SwigClassWrapper
+type(SwigClassWrapper) :: farg1
+type(C_PTR) :: fresult
+end function
+
+subroutine swigc_TpetraOperator_init(farg1, farg2) &
+bind(C, name="swigc_TpetraOperator_init")
+use, intrinsic :: ISO_C_BINDING
+import :: SwigClassWrapper
+type(SwigClassWrapper) :: farg1
+type(C_PTR), value :: farg2
+end subroutine
+
+function swigc_new_TpetraOperator() &
+bind(C, name="swigc_new_TpetraOperator") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+import :: SwigClassWrapper
+type(SwigClassWrapper) :: fresult
+end function
+
+function swigc_TpetraOperator_getDomainMap(farg1) &
+bind(C, name="swigc_TpetraOperator_getDomainMap") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+import :: SwigClassWrapper
+type(SwigClassWrapper) :: farg1
+type(SwigClassWrapper) :: fresult
+end function
+
+function swigc_TpetraOperator_getRangeMap(farg1) &
+bind(C, name="swigc_TpetraOperator_getRangeMap") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+import :: SwigClassWrapper
+type(SwigClassWrapper) :: farg1
+type(SwigClassWrapper) :: fresult
+end function
+
+subroutine swigc_TpetraOperator_apply(farg1, farg2, farg3, farg4, farg5, farg6) &
+bind(C, name="swigc_TpetraOperator_apply")
+use, intrinsic :: ISO_C_BINDING
+import :: SwigClassWrapper
+type(SwigClassWrapper) :: farg1
+type(SwigClassWrapper) :: farg2
+type(SwigClassWrapper) :: farg3
+integer(C_INT), intent(in) :: farg4
+real(C_DOUBLE), intent(in) :: farg5
+real(C_DOUBLE), intent(in) :: farg6
+end subroutine
+
+subroutine swigc_delete_TpetraOperator(farg1) &
+bind(C, name="swigc_delete_TpetraOperator")
+use, intrinsic :: ISO_C_BINDING
+import :: SwigClassWrapper
+type(SwigClassWrapper) :: farg1
+end subroutine
+
+  subroutine swigc_assignment_TpetraOperator(self, other) &
+     bind(C, name="swigc_assignment_TpetraOperator")
    use, intrinsic :: ISO_C_BINDING
    import :: SwigClassWrapper
    type(SwigClassWrapper), intent(inout) :: self
@@ -6132,6 +6226,179 @@ end subroutine
    type(TpetraMultiVector), intent(in) :: other
    call swigc_assignment_TpetraMultiVector(self%swigdata, other%swigdata)
   end subroutine
+function swigf_TpetraOperator_fhandle(self) &
+result(swig_result)
+use, intrinsic :: ISO_C_BINDING
+type(C_PTR) :: swig_result
+class(TpetraOperator), intent(in) :: self
+type(C_PTR) :: fresult 
+type(SwigClassWrapper) :: farg1 
+
+farg1 = self%swigdata
+fresult = swigc_TpetraOperator_fhandle(farg1)
+swig_result = fresult
+end function
+
+subroutine swigf_TpetraOperator_init(self, fh)
+use, intrinsic :: ISO_C_BINDING
+class(TpetraOperator), intent(inout) :: self
+type(C_PTR) :: fh
+type(SwigClassWrapper) :: farg1 
+type(C_PTR) :: farg2 
+
+farg1 = self%swigdata
+farg2 = fh
+call swigc_TpetraOperator_init(farg1, farg2)
+end subroutine
+
+function new_TpetraOperator() &
+result(self)
+use, intrinsic :: ISO_C_BINDING
+type(TpetraOperator) :: self
+type(SwigClassWrapper) :: fresult 
+
+fresult = swigc_new_TpetraOperator()
+self%swigdata = fresult
+end function
+
+function swigf_TpetraOperator_getDomainMap(self) &
+result(swig_result)
+use, intrinsic :: ISO_C_BINDING
+type(TpetraMap) :: swig_result
+class(TpetraOperator), intent(in) :: self
+type(SwigClassWrapper) :: fresult 
+type(SwigClassWrapper) :: farg1 
+
+farg1 = self%swigdata
+fresult = swigc_TpetraOperator_getDomainMap(farg1)
+swig_result%swigdata = fresult
+end function
+
+function swigf_TpetraOperator_getRangeMap(self) &
+result(swig_result)
+use, intrinsic :: ISO_C_BINDING
+type(TpetraMap) :: swig_result
+class(TpetraOperator), intent(in) :: self
+type(SwigClassWrapper) :: fresult 
+type(SwigClassWrapper) :: farg1 
+
+farg1 = self%swigdata
+fresult = swigc_TpetraOperator_getRangeMap(farg1)
+swig_result%swigdata = fresult
+end function
+
+subroutine swigf_TpetraOperator_apply(self, x, y, mode, alpha, beta)
+use, intrinsic :: ISO_C_BINDING
+class(TpetraOperator), intent(in) :: self
+class(TpetraMultiVector), intent(in) :: x
+class(TpetraMultiVector), intent(inout) :: y
+integer(kind(TeuchosETransp)), intent(in) :: mode
+real(C_DOUBLE), intent(in) :: alpha
+real(C_DOUBLE), intent(in) :: beta
+type(SwigClassWrapper) :: farg1 
+type(SwigClassWrapper) :: farg2 
+type(SwigClassWrapper) :: farg3 
+integer(C_INT) :: farg4 
+real(C_DOUBLE) :: farg5 
+real(C_DOUBLE) :: farg6 
+
+farg1 = self%swigdata
+farg2 = x%swigdata
+farg3 = y%swigdata
+farg4 = mode
+farg5 = alpha
+farg6 = beta
+call swigc_TpetraOperator_apply(farg1, farg2, farg3, farg4, farg5, farg6)
+end subroutine
+
+subroutine delete_TpetraOperator(self)
+use, intrinsic :: ISO_C_BINDING
+class(TpetraOperator), intent(inout) :: self
+type(SwigClassWrapper) :: farg1 
+
+
+type(C_PTR) :: fself_ptr
+type(TpetraOperatorWrapper), pointer :: handle
+fself_ptr = swigc_TpetraOperator_fhandle(self%swigdata)
+call c_f_pointer(cptr=fself_ptr, fptr=handle)
+farg1 = self%swigdata
+if (self%swigdata%mem == SWIG_OWN) then
+call swigc_delete_TpetraOperator(farg1)
+end if
+self%swigdata%ptr = C_NULL_PTR
+self%swigdata%mem = SWIG_NULL
+
+! Release the allocated handle
+deallocate(handle)
+end subroutine
+
+  subroutine swigf_assignment_TpetraOperator(self, other)
+   use, intrinsic :: ISO_C_BINDING
+   class(TpetraOperator), intent(inout) :: self
+   type(TpetraOperator), intent(in) :: other
+   call swigc_assignment_TpetraOperator(self%swigdata, other%swigdata)
+  end subroutine
+
+! Convert a ISO-C class pointer struct into a user Fortran native pointer
+subroutine c_f_pointer_TpetraOperator(clswrap, fptr)
+  type(SwigClassWrapper), intent(in) :: clswrap
+  class(TpetraOperator), pointer, intent(out) :: fptr
+  type(TpetraOperatorWrapper), pointer :: handle
+  type(C_PTR) :: fself_ptr
+  ! Convert C handle to fortran pointer
+  fself_ptr = swigc_TpetraOperator_fhandle(clswrap)
+  ! *** NOTE *** : gfortran 5 through 7 falsely claim the next line is not standards compliant. Since 'handle' is a scalar and
+  ! not an array it should be OK, but TS29113 explicitly removes the interoperability requirement for fptr.
+  ! Error: TS 29113/TS 18508: Noninteroperable array FPTR at (1) to C_F_POINTER: Expression is a noninteroperable derived type
+  ! see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84924
+  call c_f_pointer(cptr=fself_ptr, fptr=handle)
+  ! Access the pointer inside that
+  fptr => handle%data
+end subroutine
+
+! Convert SWIG array wrapper to temporary Fortran string, pass to the fortran
+! cb function, convert back to SWIG array wrapper.
+! This function must have input/output arguments compatible with ISO C, and it must be marked with "bind(C)"
+subroutine swigd_TpetraOperator_apply(fself, farg1, farg2, farg3, farg4, farg5) &
+    bind(C, name="swigd_TpetraOperator_apply")
+  use, intrinsic :: ISO_C_BINDING
+  implicit none
+  type(SwigClassWrapper), intent(in) :: fself
+  type(SwigClassWrapper), intent(in) :: farg1
+  type(SwigClassWrapper), intent(in) :: farg2
+  integer(C_INT), intent(in) :: farg3
+  real(C_DOUBLE), intent(in) :: farg4
+  real(C_DOUBLE), intent(in) :: farg5
+
+  class(TpetraOperator), pointer :: self
+  type(TpetraMultiVector) :: x
+  type(TpetraMultiVector) :: y
+  integer(kind(TeuchosETransp)) :: mode
+  real(C_DOUBLE) :: alpha
+  real(C_DOUBLE) :: beta
+
+  ! Get pointer to Fortran object from class wrapper
+  call c_f_pointer_TpetraOperator(fself, self)
+  ! Convert class references to fortran proxy references
+  x%swigdata = farg1
+  y%swigdata = farg2
+  ! Copy scalars
+  mode  = int(farg3, kind(TeuchosETransp))
+  alpha = farg4
+  beta  = farg5
+  ! Call fortran function pointer with native fortran input/output
+  call self%apply(x, y, mode, alpha, beta)
+end subroutine
+
+subroutine init_TpetraOperator(self)
+  class(TpetraOperator), target :: self
+  type(TpetraOperatorWrapper), pointer :: handle
+  allocate(handle)
+  handle%data => self
+  self%swigdata = swigc_new_TpetraOperator()
+  call swigc_TpetraOperator_init(self%swigdata, c_loc(handle))
+end subroutine
+
 subroutine RowInfo_localRow_set(self, localrow)
 use, intrinsic :: ISO_C_BINDING
 class(RowInfo), intent(inout) :: self

--- a/src/tpetra/src/fortpetra.i
+++ b/src/tpetra/src/fortpetra.i
@@ -82,7 +82,7 @@ public :: norm_type
 /* %include "Tpetra_DistObject.i" */
 %include "Tpetra_MultiVector.i"
 /* %include "Tpetra_Vector.i" */        // needs better support for inheritance
-/* %include "Tpetra_Operator.i" */      // needs to understand that Tpetra::MultiVector<SC,LO,GO,NO,false> and Tpetra::MultiVector<SC,LO,GO,NO> are the same thing
+%include "Tpetra_Operator.i"
 %include "Tpetra_CrsGraph.i"
 /* %include "Tpetra_RowMatrix.i" */     // needs better support for abstract classes
 %include "Tpetra_CrsMatrix.i"

--- a/src/tpetra/src/fortpetraFORTRAN_wrap.cxx
+++ b/src/tpetra/src/fortpetraFORTRAN_wrap.cxx
@@ -687,6 +687,70 @@ SWIGINTERN void Tpetra_MultiVector_Sl_SC_Sc_LO_Sc_GO_Sc_NO_Sg__doExport__SWIG_1(
       self->doExport(source, importer, CM);
     }
 
+#include "Tpetra_Operator.hpp"
+
+
+extern "C" {
+/* Fortran BIND(C) function */
+SwigArrayWrapper swigd_TpetraOperator_apply(
+        SwigClassWrapper const *fself,
+        SwigClassWrapper const *farg1,
+        SwigClassWrapper const *farg2,
+        int *farg3,
+        double const *farg4,
+        double const *farg5
+        );
+}
+
+
+  class TpetraOperator : public Tpetra::Operator<SC,LO,GO,NO> {
+    // Pointer to polymorphic fortran pointer
+    void* fhandle_;
+   public:
+    /* DIRECTOR FUNCTIONS */
+    const void* fhandle() const { return this->fhandle_; }
+    void init(void* fh) { fhandle_ = fh; }
+
+    /* TPETRA */
+    typedef Tpetra::MultiVector<SC,LO,GO,NO> MV_type;
+    typedef Tpetra::Map<LO,GO,NO> Map_type;
+    TpetraOperator() : fhandle_(NULL) { /* * */ }
+
+
+    virtual Teuchos::RCP<const Map_type> getDomainMap() const { return Teuchos::null; }
+    virtual Teuchos::RCP<const Map_type> getRangeMap() const { return Teuchos::null; }
+
+    virtual void apply(const MV_type &X, MV_type &Y,
+                       Teuchos::ETransp mode, SC alpha, SC beta) const
+    {
+      /* construct "this" pointer */
+      SwigClassWrapper self;
+      self.ptr = const_cast<TpetraOperator*>(this);
+      self.mem = SWIG_CREF; // since this function is const
+
+      /* convert X -> class wrapper */
+      Teuchos::RCP<const Tpetra::MultiVector<SC,LO,GO,NO> > temprcp1(&X SWIG_NO_NULL_DELETER_0);
+
+      SwigClassWrapper farg1;
+      farg1.ptr = &temprcp1;
+      farg1.mem = SWIG_CREF; // X is const
+
+      Teuchos::RCP< Tpetra::MultiVector<SC,LO,GO,NO> > temprcp2(&Y SWIG_NO_NULL_DELETER_0);
+
+      SwigClassWrapper farg2;
+      farg2.ptr = &temprcp2;
+      farg2.mem = SWIG_REF; // Y is mutable
+
+      /* convert scalars to wrappers */
+      int farg3 = mode;
+      double farg4 = alpha;
+      double farg5 = beta;
+
+      swigd_TpetraOperator_apply(&self, &farg1, &farg2, &farg3, &farg4, &farg5);
+    }
+  };
+
+
 #include "Tpetra_CrsGraph.hpp"
 
 SWIGINTERN Tpetra::CrsGraph< LO,GO,NO > *new_Tpetra_CrsGraph_Sl_LO_Sc_GO_Sc_NO_Sg___SWIG_6(Teuchos::RCP< Tpetra::CrsGraph< int,long long,Kokkos::Compat::KokkosSerialWrapperNode,false >::map_type const > const &rowMap,std::pair< std::size_t const *,std::size_t > numEntPerRow,Tpetra::ProfileType const pftype=Tpetra::DynamicProfile,Teuchos::RCP< Teuchos::ParameterList > const &params=Teuchos::null){
@@ -5467,6 +5531,274 @@ SWIGEXPORT void swigc_assignment_TpetraMultiVector(SwigClassWrapper * self, Swig
   SWIG_assign(swig_lhs_classtype, self,
     swig_lhs_classtype, const_cast<SwigClassWrapper*>(other),
     0 | swig::IS_DESTR | swig::IS_COPY_CONSTR | swig::IS_COPY_ASSIGN);
+}
+
+
+SWIGEXPORT void * swigc_TpetraOperator_fhandle(SwigClassWrapper const *farg1) {
+  void * fresult ;
+  TpetraOperator *arg1 = (TpetraOperator *) 0 ;
+  Teuchos::RCP< TpetraOperator const > *smartarg1 ;
+  void *result = 0 ;
+  
+  smartarg1 = static_cast< Teuchos::RCP<const TpetraOperator >* >(farg1->ptr);
+  arg1 = smartarg1 ? const_cast<TpetraOperator*>(smartarg1->get()) : NULL;
+  {
+    // Make sure no unhandled exceptions exist before performing a new action
+    SWIG_check_unhandled_exception_impl("TpetraOperator::fhandle() const");;
+    try
+    {
+      // Attempt the wrapped function call
+      result = (void *)((TpetraOperator const *)arg1)->fhandle();
+    }
+    catch (const std::range_error& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("TpetraOperator::fhandle() const", SWIG_IndexError, e.what(), return 0);
+    }
+    catch (const std::exception& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("TpetraOperator::fhandle() const", SWIG_RuntimeError, e.what(), return 0);
+    }
+    catch (...)
+    {
+      SWIG_exception_impl("TpetraOperator::fhandle() const", SWIG_UnknownError, "An unknown exception occurred", return 0);
+    }
+  }
+  fresult = result;
+  return fresult;
+}
+
+
+SWIGEXPORT void swigc_TpetraOperator_init(SwigClassWrapper const *farg1, void *farg2) {
+  TpetraOperator *arg1 = (TpetraOperator *) 0 ;
+  void *arg2 = (void *) 0 ;
+  Teuchos::RCP< TpetraOperator > *smartarg1 ;
+  
+  smartarg1 = static_cast< Teuchos::RCP< TpetraOperator >* >(farg1->ptr);
+  arg1 = smartarg1 ? smartarg1->get() : NULL;
+  arg2 = reinterpret_cast< void * >(farg2);
+  {
+    // Make sure no unhandled exceptions exist before performing a new action
+    SWIG_check_unhandled_exception_impl("TpetraOperator::init(void *)");;
+    try
+    {
+      // Attempt the wrapped function call
+      (arg1)->init(arg2);
+    }
+    catch (const std::range_error& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("TpetraOperator::init(void *)", SWIG_IndexError, e.what(), return );
+    }
+    catch (const std::exception& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("TpetraOperator::init(void *)", SWIG_RuntimeError, e.what(), return );
+    }
+    catch (...)
+    {
+      SWIG_exception_impl("TpetraOperator::init(void *)", SWIG_UnknownError, "An unknown exception occurred", return );
+    }
+  }
+  
+}
+
+
+SWIGEXPORT SwigClassWrapper swigc_new_TpetraOperator() {
+  SwigClassWrapper fresult ;
+  TpetraOperator *result = 0 ;
+  
+  {
+    // Make sure no unhandled exceptions exist before performing a new action
+    SWIG_check_unhandled_exception_impl("TpetraOperator::TpetraOperator()");;
+    try
+    {
+      // Attempt the wrapped function call
+      result = (TpetraOperator *)new TpetraOperator();
+    }
+    catch (const std::range_error& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("TpetraOperator::TpetraOperator()", SWIG_IndexError, e.what(), return SwigClassWrapper_uninitialized());
+    }
+    catch (const std::exception& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("TpetraOperator::TpetraOperator()", SWIG_RuntimeError, e.what(), return SwigClassWrapper_uninitialized());
+    }
+    catch (...)
+    {
+      SWIG_exception_impl("TpetraOperator::TpetraOperator()", SWIG_UnknownError, "An unknown exception occurred", return SwigClassWrapper_uninitialized());
+    }
+  }
+  fresult.ptr = result ? new Teuchos::RCP< TpetraOperator >(result SWIG_NO_NULL_DELETER_1) : NULL;
+  fresult.mem = SWIG_MOVE;
+  return fresult;
+}
+
+
+SWIGEXPORT SwigClassWrapper swigc_TpetraOperator_getDomainMap(SwigClassWrapper const *farg1) {
+  SwigClassWrapper fresult ;
+  TpetraOperator *arg1 = (TpetraOperator *) 0 ;
+  Teuchos::RCP< TpetraOperator const > *smartarg1 ;
+  Teuchos::RCP< TpetraOperator::Map_type const > result;
+  
+  smartarg1 = static_cast< Teuchos::RCP<const TpetraOperator >* >(farg1->ptr);
+  arg1 = smartarg1 ? const_cast<TpetraOperator*>(smartarg1->get()) : NULL;
+  {
+    // Make sure no unhandled exceptions exist before performing a new action
+    SWIG_check_unhandled_exception_impl("TpetraOperator::getDomainMap() const");;
+    try
+    {
+      // Attempt the wrapped function call
+      result = ((TpetraOperator const *)arg1)->getDomainMap();
+    }
+    catch (const std::range_error& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("TpetraOperator::getDomainMap() const", SWIG_IndexError, e.what(), return SwigClassWrapper_uninitialized());
+    }
+    catch (const std::exception& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("TpetraOperator::getDomainMap() const", SWIG_RuntimeError, e.what(), return SwigClassWrapper_uninitialized());
+    }
+    catch (...)
+    {
+      SWIG_exception_impl("TpetraOperator::getDomainMap() const", SWIG_UnknownError, "An unknown exception occurred", return SwigClassWrapper_uninitialized());
+    }
+  }
+  fresult.ptr = (new Teuchos::RCP<const Tpetra::Map<LO,GO,NO> >(static_cast< const Teuchos::RCP<const Tpetra::Map<LO,GO,NO> >& >(result)));
+  fresult.mem = SWIG_MOVE;
+  return fresult;
+}
+
+
+SWIGEXPORT SwigClassWrapper swigc_TpetraOperator_getRangeMap(SwigClassWrapper const *farg1) {
+  SwigClassWrapper fresult ;
+  TpetraOperator *arg1 = (TpetraOperator *) 0 ;
+  Teuchos::RCP< TpetraOperator const > *smartarg1 ;
+  Teuchos::RCP< TpetraOperator::Map_type const > result;
+  
+  smartarg1 = static_cast< Teuchos::RCP<const TpetraOperator >* >(farg1->ptr);
+  arg1 = smartarg1 ? const_cast<TpetraOperator*>(smartarg1->get()) : NULL;
+  {
+    // Make sure no unhandled exceptions exist before performing a new action
+    SWIG_check_unhandled_exception_impl("TpetraOperator::getRangeMap() const");;
+    try
+    {
+      // Attempt the wrapped function call
+      result = ((TpetraOperator const *)arg1)->getRangeMap();
+    }
+    catch (const std::range_error& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("TpetraOperator::getRangeMap() const", SWIG_IndexError, e.what(), return SwigClassWrapper_uninitialized());
+    }
+    catch (const std::exception& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("TpetraOperator::getRangeMap() const", SWIG_RuntimeError, e.what(), return SwigClassWrapper_uninitialized());
+    }
+    catch (...)
+    {
+      SWIG_exception_impl("TpetraOperator::getRangeMap() const", SWIG_UnknownError, "An unknown exception occurred", return SwigClassWrapper_uninitialized());
+    }
+  }
+  fresult.ptr = (new Teuchos::RCP<const Tpetra::Map<LO,GO,NO> >(static_cast< const Teuchos::RCP<const Tpetra::Map<LO,GO,NO> >& >(result)));
+  fresult.mem = SWIG_MOVE;
+  return fresult;
+}
+
+
+SWIGEXPORT void swigc_TpetraOperator_apply(SwigClassWrapper const *farg1, SwigClassWrapper const *farg2, SwigClassWrapper const *farg3, int const *farg4, double const *farg5, double const *farg6) {
+  TpetraOperator *arg1 = (TpetraOperator *) 0 ;
+  TpetraOperator::MV_type *arg2 = 0 ;
+  TpetraOperator::MV_type *arg3 = 0 ;
+  Teuchos::ETransp arg4 ;
+  SC arg5 ;
+  SC arg6 ;
+  Teuchos::RCP< TpetraOperator const > *smartarg1 ;
+  Teuchos::RCP< Tpetra::MultiVector< SC,LO,GO,NO > const > *smartarg2 ;
+  Teuchos::RCP< Tpetra::MultiVector< SC,LO,GO,NO > > *smartarg3 ;
+  
+  smartarg1 = static_cast< Teuchos::RCP<const TpetraOperator >* >(farg1->ptr);
+  arg1 = smartarg1 ? const_cast<TpetraOperator*>(smartarg1->get()) : NULL;
+  SWIG_check_sp_nonnull(farg2, "TpetraOperator::MV_type *", "TpetraMultiVector", "TpetraOperator::apply(TpetraOperator::MV_type const &,TpetraOperator::MV_type &,Teuchos::ETransp,SC,SC) const", return )
+  smartarg2 = static_cast< Teuchos::RCP<const Tpetra::MultiVector<SC,LO,GO,NO> >* >(farg2->ptr);
+  arg2 = const_cast<Tpetra::MultiVector<SC,LO,GO,NO>*>(smartarg2->get());
+  SWIG_check_sp_nonnull(farg3, "TpetraOperator::MV_type *", "TpetraMultiVector", "TpetraOperator::apply(TpetraOperator::MV_type const &,TpetraOperator::MV_type &,Teuchos::ETransp,SC,SC) const", return )
+  smartarg3 = static_cast< Teuchos::RCP< Tpetra::MultiVector<SC,LO,GO,NO> >* >(farg3->ptr);
+  arg3 = smartarg3->get();
+  arg4 = static_cast< Teuchos::ETransp >(*farg4);
+  arg5 = *farg5;
+  arg6 = *farg6;
+  {
+    // Make sure no unhandled exceptions exist before performing a new action
+    SWIG_check_unhandled_exception_impl("TpetraOperator::apply(TpetraOperator::MV_type const &,TpetraOperator::MV_type &,Teuchos::ETransp,SC,SC) const");;
+    try
+    {
+      // Attempt the wrapped function call
+      ((TpetraOperator const *)arg1)->apply((TpetraOperator::MV_type const &)*arg2,*arg3,arg4,arg5,arg6);
+    }
+    catch (const std::range_error& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("TpetraOperator::apply(TpetraOperator::MV_type const &,TpetraOperator::MV_type &,Teuchos::ETransp,SC,SC) const", SWIG_IndexError, e.what(), return );
+    }
+    catch (const std::exception& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("TpetraOperator::apply(TpetraOperator::MV_type const &,TpetraOperator::MV_type &,Teuchos::ETransp,SC,SC) const", SWIG_RuntimeError, e.what(), return );
+    }
+    catch (...)
+    {
+      SWIG_exception_impl("TpetraOperator::apply(TpetraOperator::MV_type const &,TpetraOperator::MV_type &,Teuchos::ETransp,SC,SC) const", SWIG_UnknownError, "An unknown exception occurred", return );
+    }
+  }
+  
+}
+
+
+SWIGEXPORT void swigc_delete_TpetraOperator(SwigClassWrapper const *farg1) {
+  TpetraOperator *arg1 = (TpetraOperator *) 0 ;
+  Teuchos::RCP< TpetraOperator > *smartarg1 ;
+  
+  smartarg1 = static_cast< Teuchos::RCP< TpetraOperator >* >(farg1->ptr);
+  arg1 = smartarg1 ? smartarg1->get() : NULL;
+  {
+    // Make sure no unhandled exceptions exist before performing a new action
+    SWIG_check_unhandled_exception_impl("TpetraOperator::~TpetraOperator()");;
+    try
+    {
+      // Attempt the wrapped function call
+      (void)arg1; delete smartarg1; 
+    }
+    catch (const std::range_error& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("TpetraOperator::~TpetraOperator()", SWIG_IndexError, e.what(), return );
+    }
+    catch (const std::exception& e)
+    {
+      // Store a C++ exception
+      SWIG_exception_impl("TpetraOperator::~TpetraOperator()", SWIG_RuntimeError, e.what(), return );
+    }
+    catch (...)
+    {
+      SWIG_exception_impl("TpetraOperator::~TpetraOperator()", SWIG_UnknownError, "An unknown exception occurred", return );
+    }
+  }
+  
+}
+
+
+SWIGEXPORT void swigc_assignment_TpetraOperator(SwigClassWrapper * self, SwigClassWrapper const * other) {
+  typedef Teuchos::RCP< TpetraOperator > swig_lhs_classtype;
+  SWIG_assign(swig_lhs_classtype, self,
+    swig_lhs_classtype, const_cast<SwigClassWrapper*>(other),
+    0 | swig::IS_DESTR | swig::IS_COPY_CONSTR);
 }
 
 

--- a/src/tpetra/test/CMakeLists.txt
+++ b/src/tpetra/test/CMakeLists.txt
@@ -12,6 +12,7 @@ SET(TESTS
   test_tpetra_crsgraph.f90
   test_tpetra_crsmatrix.f90
   test_tpetra_multivector.f90
+  test_tpetra_operator.f90
   test_tpetra_import_export.f90
   )
 

--- a/src/tpetra/test/test_tpetra_operator.f90
+++ b/src/tpetra/test/test_tpetra_operator.f90
@@ -1,0 +1,72 @@
+! Copyright 2018, UT-Battelle, LLC
+!
+! SPDX-License-Identifier: BSD-3-Clause
+! License-Filename: LICENSE
+module myoperators
+  use forteuchos
+  use fortpetra
+  implicit none
+
+  type, extends(TpetraOperator) :: MyOperator
+    contains
+    procedure :: apply => apply_my_operator
+  end type
+contains
+  subroutine apply_my_operator(self, x, y, mode, alpha, beta)
+    use, intrinsic :: ISO_C_BINDING
+    implicit none
+    class(MyOperator), intent(in) :: self
+    class(TpetraMultiVector), intent(in) :: x
+    class(TpetraMultiVector), intent(inout) :: y
+    integer(kind(TeuchosETransp)), intent(in) :: mode
+    real(C_DOUBLE), intent(in) :: alpha
+    real(C_DOUBLE), intent(in) :: beta
+
+    ! TODO
+
+  end subroutine
+end module
+
+program test_TpetraOperator
+#include "ForTrilinosTpetra_config.hpp"
+#include "FortranTestUtilities.h"
+  use iso_fortran_env
+  use, intrinsic :: iso_c_binding
+  use forteuchos
+  use fortpetra
+  use myoperators
+
+  implicit none
+  type(TeuchosComm) :: comm
+  integer(global_size_type), parameter :: invalid = -1
+  character(len=256), parameter :: FILENAME="test_tpetra_operator.f90"
+
+
+  SETUP_TEST()
+
+#ifdef HAVE_MPI
+  comm = TeuchosComm(MPI_COMM_WORLD); FORTRILINOS_CHECK_IERR()
+#else
+  comm = TeuchosComm(); FORTRILINOS_CHECK_IERR()
+#endif
+
+  ADD_SUBTEST_AND_RUN(TpetraOperator_Build)
+
+  call comm%release()
+
+  TEARDOWN_TEST()
+
+contains
+
+! --------------------------------description--------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraOperator_Build)
+    class(TpetraOperator), allocatable :: op
+
+    allocate(op, source=MyOperator())
+    call init_TpetraOperator(op); TEST_IERR()
+
+    call op%release()
+    deallocate(op)
+  END_FORTRILINOS_UNIT_TEST(TpetraOperator_Build)
+
+end program test_TpetraOperator


### PR DESCRIPTION
This is an initial implementation of the callback functionality for the Tpetra operator. I've included a skeleton for a unit test that demonstrates its use. This MR supersedes #220 , most of #207 (aside from the int/logical type conversions), and the largest parts of #217.

Closes #163, #177, #185, #219 