### PR TITLE
Add workarounds/notices of CMake issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,8 @@ IF (${PACKAGE_NAME}_ENABLE_DeveloperMode)
           "directory, since they will not contain MPI-related classes.")
     ELSE()
         # Export the newly generated wrappers to the source directory.
-        SET(ForTrilinos_EXPORT_SWIG TRUE)
+        SET(ForTrilinos_EXPORT_SWIG TRUE CACHE BOOL
+          "Build SWIG wrapper files in the source directory")
     ENDIF()
 ENDIF()
 


### PR DESCRIPTION
CMake 3.11 changed how SWIG module targets are created, which breaks the cmake script when using Makefiles. This change means an immediate failure rather than a woefully confusing build error. It also allows SWIG source files to be generated in the build directory even if MPI and developer mode are enabled.