### PR TITLE
IoC: properly release base class memory

### DIFF
--- a/src/interface/src/fortrilinos.f90
+++ b/src/interface/src/fortrilinos.f90
@@ -1244,11 +1244,12 @@ function swigd_ForModelEvaluator_create_operator(fself) &
 end function
 
 subroutine init_ForModelEvaluator(self)
+  ! Note: subclass should call `self = ForModelEvaluator()` in its
+  ! initialization code *before* doing this
   class(ForModelEvaluator), target :: self
   type(ForModelEvaluatorHandle), pointer :: handle
   allocate(handle)
   handle%data => self
-  self%swigdata = swigc_new_ForModelEvaluator()
   call swigc_ForModelEvaluator_init(self%swigdata, c_loc(handle))
 end subroutine
 

--- a/src/interface/src/nox.i
+++ b/src/interface/src/nox.i
@@ -360,11 +360,12 @@ function swigd_ForModelEvaluator_create_operator(fself) &
 end function
 
 subroutine init_ForModelEvaluator(self)
+  ! Note: subclass should call `self = ForModelEvaluator()` in its
+  ! initialization code *before* doing this
   class(ForModelEvaluator), target :: self
   type(ForModelEvaluatorHandle), pointer :: handle
   allocate(handle)
   handle%data => self
-  self%swigdata = swigc_new_ForModelEvaluator()
   call swigc_ForModelEvaluator_init(self%swigdata, c_loc(handle))
 end subroutine
 %}

--- a/src/interface/test/Tpetra_ModelEvaluator_1DFEM.f90
+++ b/src/interface/test/Tpetra_ModelEvaluator_1DFEM.f90
@@ -143,6 +143,8 @@ contains
     type(TpetraCrsGraph) :: graph
     ! ------------------------------------------------------------------------ !
 
+    self = ForModelEvaluator()
+
     self%comm = comm
     num_nodes = num_global_elems + 1;
 

--- a/src/interface/test/test_solver_handle.f90
+++ b/src/interface/test/test_solver_handle.f90
@@ -25,6 +25,7 @@ contains
     use, intrinsic :: ISO_C_BINDING
     type(TpetraMap), intent(in) :: row_map, col_map
     type(TriDiagOperator) :: self
+    self = ForTpetraOperator()
     self%row_map = row_map
     self%col_map = col_map
     self%domain_map = row_map

--- a/src/tpetra/src/Tpetra_Operator.i
+++ b/src/tpetra/src/Tpetra_Operator.i
@@ -255,11 +255,12 @@ function swigd_ForTpetraOperator_getRangeMap(fself) &
 end function
 
 subroutine init_ForTpetraOperator(self)
+  ! Note: subclass should call `self = ForTpetraOperator()` in its
+  ! initialization code *before* doing this
   class(ForTpetraOperator), target :: self
   type(ForTpetraOperatorHandle), pointer :: handle
   allocate(handle)
   handle%data => self
-  self%swigdata = swigc_new_ForTpetraOperator()
   call swigc_ForTpetraOperator_init(self%swigdata, c_loc(handle))
 end subroutine
 %}

--- a/src/tpetra/src/fortpetra.f90
+++ b/src/tpetra/src/fortpetra.f90
@@ -6547,11 +6547,12 @@ function swigd_ForTpetraOperator_getRangeMap(fself) &
 end function
 
 subroutine init_ForTpetraOperator(self)
+  ! Note: subclass should call `self = ForTpetraOperator()` in its
+  ! initialization code *before* doing this
   class(ForTpetraOperator), target :: self
   type(ForTpetraOperatorHandle), pointer :: handle
   allocate(handle)
   handle%data => self
-  self%swigdata = swigc_new_ForTpetraOperator()
   call swigc_ForTpetraOperator_init(self%swigdata, c_loc(handle))
 end subroutine
 


### PR DESCRIPTION
Because the base class was never explicitly assigned, it's memory was
SWIG_MOVE and and not SWIG_OWN. This later resulted in memory not being
released during delete call.

Co-authored-by: Seth R Johnson <johnsonsr@ornl.gov>