### PR TITLE
Improve test coverage of CrsGraph and CrsMatrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-build
+build*
 *_autogen.f90
 *~
+.*.swp
+docker/.env
+TriBITS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@
 ##---------------------------------------------------------------------------##
 
 TRIBITS_PACKAGE_DECL(ForTrilinos)
-set(ForTrilinos_PROJECT_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 ##---------------------------------------------------------------------------##
 ## Set up package-specific options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@
 ##---------------------------------------------------------------------------##
 
 TRIBITS_PACKAGE_DECL(ForTrilinos)
+set(ForTrilinos_PROJECT_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 ##---------------------------------------------------------------------------##
 ## Set up package-specific options

--- a/cmake/CheckSWIGFortran.cmake
+++ b/cmake/CheckSWIGFortran.cmake
@@ -13,8 +13,6 @@ if (NOT SWIG_CHECKED_FORTRAN)
     OUTPUT_VARIABLE SWIG_help_output
     ERROR_VARIABLE SWIG_help_output
     RESULT_VARIABLE SWIG_help_result)
-  MESSAGE(STATUS "SWIG_help_result: ${SWIG_help_result}")
-  MESSAGE(STATUS "SWIG_help_output: ${SWIG_help_output}")
   if (NOT SWIG_help_output MATCHES "Fortran")
     message(FATAL_ERROR "This version of SWIG does not support Fortran "
       "wrapping. Please install the version from "

--- a/cmake/CheckSWIGFortran.cmake
+++ b/cmake/CheckSWIGFortran.cmake
@@ -13,6 +13,8 @@ if (NOT SWIG_CHECKED_FORTRAN)
     OUTPUT_VARIABLE SWIG_help_output
     ERROR_VARIABLE SWIG_help_output
     RESULT_VARIABLE SWIG_help_result)
+  MESSAGE(STATUS "SWIG_help_result: ${SWIG_help_result}")
+  MESSAGE(STATUS "SWIG_help_output: ${SWIG_help_output}")
   if (NOT SWIG_help_output MATCHES "Fortran")
     message(FATAL_ERROR "This version of SWIG does not support Fortran "
       "wrapping. Please install the version from "

--- a/docs/source/developer_tools.rst
+++ b/docs/source/developer_tools.rst
@@ -31,12 +31,15 @@ Then to launch an interactive Bash session inside that container, do:
 
     [host]$ docker-compose exec fortrilinos_dev bash
 
-Patch, configure, build, and test as you would usually do:
+The docker container supports building and testing with both gfortran and flang.
+Patch, configure, build, and test as you would usually do (ignore the flang step
+if using gfortran):
 
 .. code:: bash
 
     [container]$ cd $TRILINOS_DIR/ForTrilinos
     [container]$ mkdir build && cd build
+    [container]$ source ../scripts/docker_flang70_env.sh /scratch/spack # if flang
     [container]$ ../scripts/docker_cmake
     [container]$ make -j<N>
     [container]$ ctest -j<N>
@@ -78,5 +81,5 @@ This can be done by adding the following configuration options to the script (as
 
 
 .. .. warning::
-.. 
+..
     .. When using the developer mode, all of the patches ``scripts/patches`` directory of the ForTrilinos source tree must be applied.  If you previously used the ``scripts/patches/apply-patches`` script, this was done for you. Otherwise, be sure that all of the patches are applied.

--- a/scripts/autogen_tests.py
+++ b/scripts/autogen_tests.py
@@ -215,10 +215,10 @@ def main():
         if proc in ('create', 'release'):
             continue
 
-        if proc.startswith(('set_', 'get_')):
-            # Not sure about RowInfo right now
-            assert 'RowInfo' in proc2
-            continue
+        #if proc.startswith(('set_', 'get_')):
+        #    # Not sure about RowInfo right now
+        #    assert 'RowInfo' in proc2
+        #    continue
 
         namespace, proc2 = proc2.split('_', 1)
 

--- a/src/interface/test/CMakeLists.txt
+++ b/src/interface/test/CMakeLists.txt
@@ -6,6 +6,8 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(Interface_cp
   SOURCE_FILES stratimikos.xml davidson.xml LHS_matrix.mat RHS_matrix.mat nox_params.xml
  )
 
+INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
+
 IF (${PACKAGE_NAME}_ENABLE_Belos AND ${PACKAGE_NAME}_ENABLE_Ifpack2)
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
@@ -20,6 +22,14 @@ IF (${PACKAGE_NAME}_ENABLE_Belos AND ${PACKAGE_NAME}_ENABLE_Ifpack2)
     LINKER_LANGUAGE Fortran
     COMM serial mpi
   )
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    test_solver_unit
+    SOURCES test_solver_unit.F90
+    LINKER_LANGUAGE Fortran
+    COMM serial mpi
+    NUM_MPI_PROCS 4
+    )
 
 ENDIF()
 
@@ -45,6 +55,14 @@ IF (${PACKAGE_NAME}_ENABLE_Anasazi)
     LINKER_LANGUAGE Fortran
     COMM serial mpi
     NUM_MPI_PROCS 1
+    )
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    test_eigen_unit
+    SOURCES test_eigen_unit.F90
+    LINKER_LANGUAGE Fortran
+    COMM serial mpi
+    NUM_MPI_PROCS 4
     )
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(

--- a/src/interface/test/test_eigen_handle.F90
+++ b/src/interface/test/test_eigen_handle.F90
@@ -23,7 +23,6 @@ program main
   implicit none
 
   integer :: my_rank, num_procs
-
   integer(global_size_type) :: n_global
   integer:: i, n
   integer(size_type) :: max_entries_per_row

--- a/src/interface/test/test_eigen_handle.cpp
+++ b/src/interface/test/test_eigen_handle.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
         A->insertGlobalValues (gblRow,
                                tuple<GO> (gblRow, gblRow + 1),
                                tuple<SC> (2.0, -1.0));
-      } else if (static_cast<Tpetra::global_size_t> (gblRow) == numGlobalElements - 1) {
+      } else if (static_cast<Tpetra::global_size_t> (gblRow) == static_cast<Tpetra::global_size_t>(numGlobalElements - 1)) {
         // A(N-1, N-2:N-1) = [-1, 2]
         A->insertGlobalValues (gblRow,
                                tuple<GO> (gblRow - 1, gblRow),

--- a/src/interface/test/test_eigen_unit.F90
+++ b/src/interface/test/test_eigen_unit.F90
@@ -1,0 +1,244 @@
+!Copyright 2017-2018, UT-Battelle, LLC
+!
+!SPDX-License-Identifier: BSD-3-Clause
+!License-Filename: LICENSE
+program test_TrilinosEigenSolver
+
+#include "ForTrilinosInterface_config.hpp"
+#include "ForTrilinos.h"
+#include "FortranTestUtilities.h"
+  use iso_fortran_env
+  use, intrinsic :: iso_c_binding
+  use forteuchos
+  use fortrilinos
+  use fortpetra
+  use test_tpetra_crsmatrix_helper
+
+  implicit none
+  type(TeuchosComm) :: comm
+  character(len=30), parameter :: FILENAME="test_eigen_unit.F90"
+  integer, parameter :: dp = kind(0.d0)
+
+  SETUP_TEST()
+
+#ifdef HAVE_MPI
+  comm = TeuchosComm(MPI_COMM_WORLD); FORTRILINOS_CHECK_IERR()
+#else
+  comm = TeuchosComm(); FORTRILINOS_CHECK_IERR()
+#endif
+
+  ADD_SUBTEST_AND_RUN(TrilinosEigenSolver_setup_matrix)
+  ADD_SUBTEST_AND_RUN(TrilinosEigenSolver_setup_matrix_rhs)
+  ADD_SUBTEST_AND_RUN(TrilinosEigenSolver_setup_solver)
+  ADD_SUBTEST_AND_RUN(TrilinosEigenSolver_finalize)
+  ADD_SUBTEST_AND_RUN(TrilinosEigenSolver_solve)
+
+  ! No need to test at this level
+  !ADD_SUBTEST_AND_RUN(TrilinosEigenSolver_setup_operator)
+  !ADD_SUBTEST_AND_RUN(TrilinosEigenSolver_setup_operator_rhs)
+
+
+  call comm%release()
+
+  TEARDOWN_TEST()
+
+contains
+
+  ! -------------------------------setup_matrix------------------------------- !
+  FORTRILINOS_UNIT_TEST(TrilinosEigenSolver_setup_matrix)
+    type(TrilinosEigenSolver) :: eig
+    type(TpetraCrsMatrix) :: a
+    OUT0("Starting TrilinosEigenSolver_setup_matrix!")
+
+    call Tpetra_CrsMatrix_CreateIdentity(comm, a)
+    eig = TrilinosEigenSolver(); TEST_IERR()
+    call eig%init(comm); TEST_IERR()
+    TEST_NOTHROW(call eig%setup_matrix(a))
+
+    call a%release(); TEST_IERR()
+    call eig%finalize(); TEST_IERR()
+    call eig%release(); TEST_IERR()
+
+    OUT0("Finished TrilinosEigenSolver_setup_matrix!")
+
+  END_FORTRILINOS_UNIT_TEST(TrilinosEigenSolver_setup_matrix)
+
+  ! -----------------------------setup_matrix_rhs----------------------------- !
+    FORTRILINOS_UNIT_TEST(TrilinosEigenSolver_setup_matrix_rhs)
+    type(TrilinosEigenSolver) :: eig
+    type(TpetraCrsMatrix) :: a
+    OUT0("Starting TrilinosEigenSolver_setup_matrix_rhs!")
+
+    call Tpetra_CrsMatrix_CreateIdentity(comm, a)
+    eig = TrilinosEigenSolver(); TEST_IERR()
+    call eig%init(comm); TEST_IERR()
+    TEST_NOTHROW(call eig%setup_matrix_rhs(a))
+
+    call a%release(); TEST_IERR()
+    call eig%finalize(); TEST_IERR()
+    call eig%release(); TEST_IERR()
+
+    OUT0("Finished TrilinosEigenSolver_setup_matrix_rhs!")
+
+  END_FORTRILINOS_UNIT_TEST(TrilinosEigenSolver_setup_matrix_rhs)
+
+#if 0
+  ! ------------------------------setup_operator------------------------------ !
+  FORTRILINOS_UNIT_TEST(TrilinosEigenSolver_setup_operator)
+    type(TrilinosEigenSolver) :: eig
+    type(TpetraMap) :: map
+    type(TpetraOperator) :: a
+    OUT0("Starting TrilinosEigenSolver_setup_operator!")
+
+    map = TpetraMap(TPETRA_GLOBAL_INVALID, 5, comm)
+    a = TpetraOperator(); TEST_IERR()
+    !call a%fillComplete()
+    eig = TrilinosEigenSolver(); TEST_IERR()
+    call eig%init(comm); TEST_IERR()
+    TEST_NOTHROW(call eig%setup_operator(a))
+
+    call a%release(); TEST_IERR()
+    call map%release(); TEST_IERR()
+    call eig%finalize(); TEST_IERR()
+    call eig%release(); TEST_IERR()
+
+    OUT0("Finished TrilinosEigenSolver_setup_operator!")
+
+  END_FORTRILINOS_UNIT_TEST(TrilinosEigenSolver_setup_operator)
+
+  ! ----------------------------setup_operator_rhs---------------------------- !
+  FORTRILINOS_UNIT_TEST(TrilinosEigenSolver_setup_operator_rhs)
+    type(TrilinosEigenSolver) :: eig
+    type(TpetraMap) :: map
+    type(TpetraOperator) :: a
+    OUT0("Starting TrilinosEigenSolver_setup_operator_rhs!")
+
+    map = TpetraMap(TPETRA_GLOBAL_INVALID, 5, comm)
+    a = TpetraOperator(); TEST_IERR()
+    !call a%fillComplete()
+    eig = TrilinosEigenSolver(); TEST_IERR()
+    call eig%init(comm); TEST_IERR()
+    TEST_NOTHROW(call eig%setup_operator_rhs(a))
+
+    call a%release(); TEST_IERR()
+    call map%release(); TEST_IERR()
+    call eig%finalize(); TEST_IERR()
+    call eig%release(); TEST_IERR()
+
+    OUT0("Finished TrilinosEigenSolver_setup_operator_rhs!")
+
+  END_FORTRILINOS_UNIT_TEST(TrilinosEigenSolver_setup_operator_rhs)
+#endif
+
+  ! -------------------------------setup_solver------------------------------- !
+  FORTRILINOS_UNIT_TEST(TrilinosEigenSolver_setup_solver)
+    type(TrilinosEigenSolver) :: eig
+    type(ParameterList) :: plist
+    type(TpetraCrsMatrix) :: A
+    integer :: num_eigen
+    OUT0("Starting TrilinosEigenSolver_setup_solver!")
+
+    plist = ParameterList('Anasazi'); FORTRILINOS_CHECK_IERR()
+    TEST_NOTHROW(call load_from_xml(plist, 'davidson.xml'))
+
+    call plist%set('NumEV', num_eigen); FORTRILINOS_CHECK_IERR()
+    eig = TrilinosEigenSolver(); TEST_IERR()
+    call eig%init(comm); TEST_IERR()
+    call  Tpetra_CrsMatrix_CreateTestMatrix_A(comm,A)
+    call A%fillComplete(); FORTRILINOS_CHECK_IERR()
+    call eig%setup_matrix(A); TEST_IERR()
+
+    TEST_THROW(call eig%setup_solver(plist))
+
+    call plist%release(); TEST_IERR()
+    call A%release(); TEST_IERR()
+    call eig%finalize(); TEST_IERR()
+    call eig%release(); TEST_IERR()
+
+    OUT0("Finished TrilinosEigenSolver_setup_solver!")
+
+  END_FORTRILINOS_UNIT_TEST(TrilinosEigenSolver_setup_solver)
+  ! ----------------------------------solve----------------------------------- !
+  FORTRILINOS_UNIT_TEST(TrilinosEigenSolver_solve)
+    integer:: n
+    integer :: num_eigen = 1, num_found_eigen, sub_dim, restart_dim
+    type(ParameterList) :: plist, dlist
+    type(TrilinosEigenSolver) :: eigensolver
+    type(TpetraCrsMatrix) :: A
+    type(TpetraMultiVector) :: X
+    real(scalar_type), dimension(:), allocatable :: evalues
+    integer(int_type), dimension(:), allocatable :: eindex
+
+    ! Literally copy-paste from fat test, all previous functions required
+    ! for this to make any sense
+    OUT0("Starting TrilinosEigenSolver_solve!")
+
+    call  Tpetra_CrsMatrix_CreateTestMatrix_A(comm,A)
+    call A%fillComplete(); FORTRILINOS_CHECK_IERR()
+    n = A%getNodeNumRows()
+    num_eigen = 1
+
+    ! This xml file was for another matrix, and we are repurposing but then
+    ! rewriting the parameters for our test
+    plist = ParameterList('Anasazi'); TEST_IERR()
+    call load_from_xml(plist, 'davidson.xml'); TEST_IERR()
+    call plist%set("NumEV", num_eigen); FORTRILINOS_CHECK_IERR()
+    dlist = plist%sublist('Generalized Davidson')
+    sub_dim = (num_eigen+2)*comm%getSize()
+    call dlist%set("Maximum Subspace Dimension", sub_dim); FORTRILINOS_CHECK_IERR()
+    restart_dim = (num_eigen+1)*comm%getSize()
+    call dlist%set("Restart Dimension", restart_dim); FORTRILINOS_CHECK_IERR()
+
+    allocate(evalues(2*num_eigen))
+    allocate(eindex(2*num_eigen))
+
+    eigensolver = TrilinosEigenSolver(); TEST_IERR()
+
+    call eigensolver%init(comm); TEST_IERR()
+    call eigensolver%setup_matrix(A); TEST_IERR()
+    call eigensolver%setup_solver(plist); TEST_IERR()
+    num_found_eigen = eigensolver%solve(evalues, X, eindex)
+
+    TEST_EQUALITY(num_found_eigen, num_eigen)
+    ! This matrix has lambda=3:
+    ! See src/tpetra/test/test_tpetra_crsmatrix_helper.F90
+    ! Why this this isn't working:
+    !TEST_FLOATING_EQUALITY(real(3.,mag_type), real(evalues(1),mag_type), epsilon(real(3, mag_type)))
+    if (abs(real(3.,mag_type)- evalues(1)) >  epsilon(3.)) then
+       write(*,*) "Eigenvalue solver failed"
+       stop 1
+    endif
+    ! Check to make sure the second eigenvalue is 0
+    if (abs(real(0.,mag_type)- evalues(0)) >  epsilon(3.)) then
+       write(*,*) "Eigenvalue solver failed"
+       stop 1
+    endif
+
+    call eigensolver%finalize(); TEST_IERR()
+
+    call eigensolver%release(); TEST_IERR()
+    call plist%release(); TEST_IERR()
+    call dlist%release(); TEST_IERR()
+    call X%release(); TEST_IERR()
+    call A%release(); TEST_IERR()
+    deallocate(eindex, evalues)
+
+    OUT0("Finished TrilinosEigenSolver_solve!")
+
+  END_FORTRILINOS_UNIT_TEST(TrilinosEigenSolver_solve)
+  ! ---------------------------------finalize--------------------------------- !
+  FORTRILINOS_UNIT_TEST(TrilinosEigenSolver_finalize)
+    type(TrilinosEigenSolver) :: eig
+    OUT0("Starting TrilinosEigenSolver_finalize!")
+
+    eig = TrilinosEigenSolver(); TEST_IERR()
+    call eig%init(comm); TEST_IERR()
+    TEST_NOTHROW(call eig%finalize())
+
+    call eig%release(); TEST_IERR()
+
+    OUT0("Finished TrilinosEigenSolver_finalize!")
+
+  END_FORTRILINOS_UNIT_TEST(TrilinosEigenSolver_finalize)
+
+end program test_TrilinosEigenSolver

--- a/src/interface/test/test_eigen_unit.F90
+++ b/src/interface/test/test_eigen_unit.F90
@@ -209,7 +209,7 @@ contains
        stop 1
     endif
     ! Check to make sure the second eigenvalue is 0
-    if (abs(real(0.,mag_type)- evalues(0)) >  epsilon(3.)) then
+    if (abs(real(0.,mag_type)- evalues(2)) >  epsilon(3.)) then
        write(*,*) "Eigenvalue solver failed"
        stop 1
     endif

--- a/src/interface/test/test_solver_handle.cpp
+++ b/src/interface/test/test_solver_handle.cpp
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
         A->insertGlobalValues (gblRow,
                                tuple<GO> (gblRow, gblRow + 1),
                                tuple<SC> (2.0, -1.0));
-      } else if (static_cast<Tpetra::global_size_t> (gblRow) == numGlobalElements - 1) {
+      } else if (static_cast<Tpetra::global_size_t> (gblRow) == static_cast<Tpetra::global_size_t>(numGlobalElements - 1)) {
         // A(N-1, N-2:N-1) = [-1, 2]
         A->insertGlobalValues (gblRow,
                                tuple<GO> (gblRow - 1, gblRow),

--- a/src/interface/test/test_solver_unit.F90
+++ b/src/interface/test/test_solver_unit.F90
@@ -1,0 +1,191 @@
+!Copyright 2017-2018, UT-Battelle, LLC
+!
+!SPDX-License-Identifier: BSD-3-Clause
+!License-Filename: LICENSE
+program test_TrilinosSolver
+#include "FortranTestUtilities.h"
+  use iso_fortran_env
+  use, intrinsic :: iso_c_binding
+  use forteuchos
+  use fortrilinos
+  use fortpetra
+  use test_tpetra_crsmatrix_helper
+
+  implicit none
+  type(TeuchosComm) :: comm
+  character(len=25), parameter :: FILENAME="test_tri_solve.F90"
+  integer, parameter :: dp = kind(0.d0)
+  integer :: my_rank, num_procs
+
+  SETUP_TEST()
+
+#ifdef HAVE_MPI
+  comm = TeuchosComm(MPI_COMM_WORLD); FORTRILINOS_CHECK_IERR()
+#else
+  comm = TeuchosComm()
+#endif
+
+  num_procs = comm%getSize()
+  my_rank = comm%getRank()
+
+  ADD_SUBTEST_AND_RUN(TrilinosSolver_setup_matrix)
+  ADD_SUBTEST_AND_RUN(TrilinosSolver_setup_solver)
+  ADD_SUBTEST_AND_RUN(TrilinosSolver_finalize)
+
+  ! Abstract class - -  no need to test
+  !ADD_SUBTEST_AND_RUN(TrilinosSolver_setup_operator)
+
+  ADD_SUBTEST_AND_RUN(TrilinosSolver_solve)
+
+  call comm%release()
+
+  TEARDOWN_TEST()
+
+contains
+
+  ! -------------------------------setup_matrix------------------------------- !
+  FORTRILINOS_UNIT_TEST(TrilinosSolver_setup_matrix)
+    type(TrilinosSolver) :: eig
+    type(TpetraMap) :: map
+    type(TpetraCrsMatrix) :: a
+    OUT0("Starting TrilinosSolver_setup_matrix!")
+
+    call Tpetra_CrsMatrix_CreateIdentity(comm, a)
+    eig = TrilinosSolver(); TEST_IERR()
+    call eig%init(comm); TEST_IERR()
+    TEST_NOTHROW(call eig%setup_matrix(a))
+
+    call a%release(); TEST_IERR()
+    call eig%finalize(); TEST_IERR()
+    call eig%release(); TEST_IERR()
+
+    OUT0("Finished TrilinosSolver_setup_matrix!")
+
+  END_FORTRILINOS_UNIT_TEST(TrilinosSolver_setup_matrix)
+
+  ! -------------------------------setup_solver------------------------------- !
+  FORTRILINOS_UNIT_TEST(TrilinosSolver_setup_solver)
+    type(TrilinosSolver) :: eig
+    type(ParameterList) :: plist
+    type(TpetraMap) :: map
+    type(TpetraCrsMatrix) :: A
+    OUT0("Starting TrilinosSolver_setup_solver!")
+
+    call Tpetra_CrsMatrix_CreateIdentity(comm, A)
+    call A%fillComplete(); FORTRILINOS_CHECK_IERR()
+
+    plist = ParameterList("Stratimikos"); FORTRILINOS_CHECK_IERR()
+    call load_from_xml(plist, 'stratimikos.xml')
+
+    eig = TrilinosSolver(); TEST_IERR()
+    call eig%init(comm); TEST_IERR()
+    call eig%setup_matrix(A); TEST_IERR()
+
+    TEST_NOTHROW(call eig%setup_solver(plist))
+
+    call plist%release(); TEST_IERR()
+    call A%release(); TEST_IERR()
+    call eig%finalize(); TEST_IERR()
+    call eig%release(); TEST_IERR()
+
+    OUT0("Finished TrilinosSolver_setup_solver!")
+
+  END_FORTRILINOS_UNIT_TEST(TrilinosSolver_setup_solver)
+  ! ----------------------------------solve----------------------------------- !
+  FORTRILINOS_UNIT_TEST(TrilinosSolver_solve)
+    ! Yes, we do need to lift the beefy part of the previous test to test this function
+
+    integer(global_size_type) :: n_global
+    integer(size_type) :: num_vecs = 1
+
+    integer :: ierr
+    integer :: i, n
+    integer(global_ordinal_type) :: offset
+
+    type(ParameterList) :: plist
+    type(TrilinosSolver) :: solver
+    type(TpetraCrsMatrix) :: A
+    type(TpetraMultiVector) :: B, X, residual
+    type(TpetraMap) :: map
+
+    real(scalar_type), dimension(:), allocatable :: rhs
+    real(norm_type), dimension(:), allocatable :: norms
+    real(scalar_type) :: r0, sone = 1., szero = 0.
+    real(scalar_type), parameter :: tol=1.e-4
+
+    OUT0("Starting TrilinosSolver_solve!")
+
+    ! Read in the parameterList
+    plist = ParameterList("Stratimikos"); FORTRILINOS_CHECK_IERR()
+    call load_from_xml(plist, 'stratimikos.xml'); FORTRILINOS_CHECK_IERR()
+
+    call  Tpetra_CrsMatrix_CreateTestMatrix_A(comm,A)
+    call A%fillComplete(); FORTRILINOS_CHECK_IERR()
+    n = A%getNodeNumRows()
+    map = A%getRowMap()
+
+    B = TpetraMultiVector(map, num_vecs); FORTRILINOS_CHECK_IERR()
+    X = TpetraMultiVector(map, num_vecs); FORTRILINOS_CHECK_IERR()
+    residual = TpetraMultiVector(map, num_vecs, .false.); FORTRILINOS_CHECK_IERR()
+
+    allocate(norms(1))
+
+    solver = TrilinosSolver(); FORTRILINOS_CHECK_IERR()
+
+    call solver%init(comm); FORTRILINOS_CHECK_IERR()
+
+    call solver%setup_matrix(A); FORTRILINOS_CHECK_IERR()
+
+    call solver%setup_solver(plist); FORTRILINOS_CHECK_IERR()
+
+    call X%randomize()
+    call B%randomize()
+
+    call A%apply(X, residual, TeuchosNO_TRANS, sone, szero); FORTRILINOS_CHECK_IERR()
+    call residual%update(sone, B, -sone); FORTRILINOS_CHECK_IERR()
+    call residual%norm2(norms); FORTRILINOS_CHECK_IERR()
+    r0 = norms(1)
+
+    ! Solve the system
+    TEST_NOTHROW(call solver%solve(B, X))
+
+     ! Check the solution
+    call A%apply(X, residual, TeuchosNO_TRANS, sone, szero); FORTRILINOS_CHECK_IERR()
+    call residual%update(sone, B, -sone); FORTRILINOS_CHECK_IERR()
+    call residual%norm2(norms); FORTRILINOS_CHECK_IERR()
+
+    if (norms(1)/r0 > tol) then
+      write(error_unit, '(A)') 'The solver did not converge to the specified residual!'
+      stop 1
+    end if
+
+   call solver%finalize(); FORTRILINOS_CHECK_IERR()
+
+    call map%release(); FORTRILINOS_CHECK_IERR()
+    call A%release(); FORTRILINOS_CHECK_IERR()
+    call solver%release(); FORTRILINOS_CHECK_IERR()
+    call plist%release(); FORTRILINOS_CHECK_IERR()
+    call X%release(); FORTRILINOS_CHECK_IERR()
+    call B%release(); FORTRILINOS_CHECK_IERR()
+    call residual%release(); FORTRILINOS_CHECK_IERR()
+    deallocate(norms)
+
+    OUT0("Finished TrilinosSolver_solve!")
+
+  END_FORTRILINOS_UNIT_TEST(TrilinosSolver_solve)
+ ! ---------------------------------finalize--------------------------------- !
+  FORTRILINOS_UNIT_TEST(TrilinosSolver_finalize)
+    type(TrilinosSolver) :: eig
+    OUT0("Starting TrilinosSolver_finalize!")
+
+    eig = TrilinosSolver(); TEST_IERR()
+    call eig%init(comm); TEST_IERR()
+    TEST_NOTHROW(call eig%finalize())
+
+    call eig%release(); TEST_IERR()
+
+    OUT0("Finished TrilinosSolver_finalize!")
+
+  END_FORTRILINOS_UNIT_TEST(TrilinosSolver_finalize)
+
+end program test_TrilinosSolver

--- a/src/teuchos/test/test_teuchos_array.F90
+++ b/src/teuchos/test/test_teuchos_array.F90
@@ -12,11 +12,16 @@ program test_TeuchosArray
 
   implicit none
   character(len=26), parameter :: FILENAME='test_teuchos_array.f90'
-
+  integer, parameter :: dp = kind(0.d0)
+  integer, parameter :: long = selected_int_kind(18)
 
   SETUP_TEST()
 
   ADD_SUBTEST_AND_RUN(TeuchosArray_Basic)
+
+  ADD_SUBTEST_AND_RUN(TeuchosArrayDbl_view)
+  ADD_SUBTEST_AND_RUN(TeuchosArrayInt_view)
+  ADD_SUBTEST_AND_RUN(TeuchosArrayLong_view)
 
   TEARDOWN_TEST()
 contains
@@ -38,6 +43,62 @@ contains
     TEST_ASSERT(size(iptr) == size(test_int))
     TEST_ASSERT(all(iptr == test_int))
 
+    call arr%release(); TEST_IERR()
+
   END_FORTRILINOS_UNIT_TEST(TeuchosArray_Basic)
+
+  FORTRILINOS_UNIT_TEST(TeuchosArrayDbl_view)
+    type(TeuchosArrayDbl) :: arr
+    real(dp), parameter, dimension(6) :: test_dbl = (/ -1.0_dp, 0.7_dp, 3.1_dp, 2.8_dp, 5.1_dp, 6.9_dp /)
+    real(dp), pointer, dimension(:) :: dptr => NULL()
+    OUT0("Starting TeuchosArrayDbl_view!")
+
+    arr = TeuchosArrayDbl(test_dbl)
+    dptr => arr%view()
+    TEST_ASSERT(associated(dptr))
+    TEST_ASSERT(size(dptr) == size(test_dbl))
+    TEST_FLOATING_ARRAY_EQUALITY(dptr, test_dbl, epsilon(dptr(1)))
+
+    call arr%release(); TEST_IERR()
+
+    OUT0("Finished TeuchosArrayDbl_view!")
+
+  END_FORTRILINOS_UNIT_TEST(TeuchosArrayDbl_view)
+
+  FORTRILINOS_UNIT_TEST(TeuchosArrayInt_view)
+    type(TeuchosArrayInt) :: arr
+    integer, parameter, dimension(6) :: test_int = (/ -1, 0, 3, 3, 5, 7 /)
+    integer, pointer, dimension(:) :: iptr => NULL()
+    OUT0("Starting TeuchosArrayInt_view!")
+
+    arr = TeuchosArrayInt(test_int)
+    iptr => arr%view()
+    TEST_ASSERT(associated(iptr))
+    TEST_ASSERT(size(iptr) == size(test_int))
+    TEST_ARRAY_EQUALITY(iptr, test_int)
+
+    call arr%release(); TEST_IERR()
+
+    OUT0("Finished TeuchosArrayInt_view!")
+
+  END_FORTRILINOS_UNIT_TEST(TeuchosArrayInt_view)
+
+  FORTRILINOS_UNIT_TEST(TeuchosArrayLong_view)
+    type(TeuchosArrayLongLong) :: arr
+    integer(long), parameter, dimension(6) :: test_long = (/ -1_long, 0_long, 3_long, 3_long, 5_long, 7_long /)
+    integer(long), pointer, dimension(:) :: lptr => NULL()
+    OUT0("Starting TeuchosArrayLong_view!")
+
+    arr = TeuchosArrayLongLong(test_long)
+    lptr => arr%view()
+    TEST_ASSERT(associated(lptr))
+    TEST_ASSERT(size(lptr) == size(test_long))
+    TEST_ARRAY_EQUALITY(lptr, test_long)
+
+    call arr%release(); TEST_IERR()
+
+    OUT0("Finished TeuchosArrayLong_view!")
+
+  END_FORTRILINOS_UNIT_TEST(TeuchosArrayLong_view)
 
 end program test_TeuchosArray

--- a/src/teuchos/test/test_teuchos_comm.F90
+++ b/src/teuchos/test/test_teuchos_comm.F90
@@ -23,6 +23,12 @@ program test_TeuchosComm
 
   ADD_SUBTEST_AND_RUN(TeuchosComm_Basic)
 
+  ! Unit tests, assume user has MPI enabled
+  ADD_SUBTEST_AND_RUN(TeuchosComm_getRank)
+  ADD_SUBTEST_AND_RUN(TeuchosComm_getSize)
+  ADD_SUBTEST_AND_RUN(TeuchosComm_barrier)
+  ADD_SUBTEST_AND_RUN(TeuchosComm_getRawMpiComm)
+
   TEARDOWN_TEST()
 contains
 
@@ -63,5 +69,82 @@ contains
     call comm%release()
 
   END_FORTRILINOS_UNIT_TEST(TeuchosComm_Basic)
+
+  ! ---------------------------------getRank---------------------------------- !
+  FORTRILINOS_UNIT_TEST(TeuchosComm_getRank)
+    type(TeuchosComm) :: comm
+    integer :: myrank_t, myrank_m, ierr
+    OUT0("Starting TeuchosComm_getRank!")
+
+#ifdef HAVE_MPI
+    comm = TeuchosComm(MPI_COMM_WORLD); TEST_IERR()
+    myrank_t = comm%getRank(); TEST_IERR()
+    call MPI_COMM_RANK(MPI_COMM_WORLD, myrank_m, ierr)
+
+    TEST_EQUALITY(myrank_t, myrank_m)
+
+    call comm%release(); TEST_IERR()
+#else
+    return
+#endif
+
+    OUT0("Finished TeuchosComm_getRank!")
+
+  END_FORTRILINOS_UNIT_TEST(TeuchosComm_getRank)
+
+  ! ---------------------------------getSize---------------------------------- !
+  FORTRILINOS_UNIT_TEST(TeuchosComm_getSize)
+    type(TeuchosComm) :: comm
+    integer :: mysize_t, mysize_m, ierr
+    OUT0("Starting TeuchosComm_getSize!")
+
+#ifdef HAVE_MPI
+    comm = TeuchosComm(MPI_COMM_WORLD); TEST_IERR()
+    mysize_t = comm%getSize(); TEST_IERR()
+    call MPI_COMM_SIZE(MPI_COMM_WORLD, mysize_m, ierr)
+
+    TEST_EQUALITY(mysize_t, mysize_m)
+
+    call comm%release(); TEST_IERR()
+#else
+    return
+#endif
+    OUT0("Finished TeuchosComm_getSize!")
+
+  END_FORTRILINOS_UNIT_TEST(TeuchosComm_getSize)
+
+  ! ---------------------------------barrier---------------------------------- !
+  FORTRILINOS_UNIT_TEST(TeuchosComm_barrier)
+    type(TeuchosComm) :: comm
+    OUT0("Starting TeuchosComm_barrier!")
+
+#ifdef HAVE_MPI
+    comm = TeuchosComm(MPI_COMM_WORLD); TEST_IERR()
+    TEST_NOTHROW(call comm%barrier())
+
+    call comm%release(); TEST_IERR()
+#else
+    return
+#endif
+    OUT0("Finished TeuchosComm_barrier!")
+
+  END_FORTRILINOS_UNIT_TEST(TeuchosComm_barrier)
+
+  ! ------------------------------getRawMpiComm------------------------------- !
+  FORTRILINOS_UNIT_TEST(TeuchosComm_getRawMpiComm)
+    type(TeuchosComm) :: comm
+    OUT0("Starting TeuchosComm_getRawMpiComm!")
+
+#ifdef HAVE_MPI
+    comm = TeuchosComm(MPI_COMM_WORLD); TEST_IERR()
+    TEST_EQUALITY(MPI_COMM_WORLD, comm%getRawMpiComm())
+
+    call comm%release(); TEST_IERR()
+#else
+    return
+#endif
+    OUT0("Finished TeuchosComm_getRawMpiComm!")
+
+  END_FORTRILINOS_UNIT_TEST(TeuchosComm_getRawMpiComm)
 
 end program test_TeuchosComm

--- a/src/teuchos/test/test_teuchos_plist.F90
+++ b/src/teuchos/test/test_teuchos_plist.F90
@@ -12,11 +12,24 @@ program test_TeuchosPList
 
   implicit none
   character(len=26), parameter :: FILENAME='test_teuchos_plist.F90'
-
+  integer, parameter :: dp = kind(0.d0)
 
   SETUP_TEST()
 
   ADD_SUBTEST_AND_RUN(TeuchosPList_Basic)
+
+  ADD_SUBTEST_AND_RUN(ParameterList_print)
+  ADD_SUBTEST_AND_RUN(ParameterList_remove)
+  ADD_SUBTEST_AND_RUN(ParameterList_is_parameter)
+  ADD_SUBTEST_AND_RUN(ParameterList_sublist)
+  ADD_SUBTEST_AND_RUN(ParameterList_get_real)
+  ADD_SUBTEST_AND_RUN(ParameterList_get_integer)
+  ADD_SUBTEST_AND_RUN(ParameterList_get_longlong)
+  ADD_SUBTEST_AND_RUN(ParameterList_get_logical)
+  ADD_SUBTEST_AND_RUN(ParameterList_get_string)
+  ADD_SUBTEST_AND_RUN(ParameterList_get_arr_real)
+  ADD_SUBTEST_AND_RUN(ParameterList_get_arr_integer)
+  ADD_SUBTEST_AND_RUN(ParameterList_get_arr_longlong)
 
   TEARDOWN_TEST()
 contains
@@ -43,7 +56,7 @@ contains
     TEST_THROW(call load_from_xml(plist, 'nonexistent_path.xml'))
     TEST_ASSERT(c_associated(plist%swigdata%cptr))
 
-    ! Get and set a vlaue
+    ! Get and set a value
     call plist%set('myint', 4)
     ival = plist%get_integer('myint')
     TEST_EQUALITY(ival, 4)
@@ -111,5 +124,216 @@ contains
     OUT0('Finished TeuchosPList_Basic!')
 
   END_FORTRILINOS_UNIT_TEST(TeuchosPList_Basic)
+
+  ! ----------------------------------print----------------------------------- !
+  FORTRILINOS_UNIT_TEST(ParameterList_print)
+    type(ParameterList) :: list
+    OUT0("Starting ParameterList_print!")
+
+    list = ParameterList('mylist'); TEST_IERR()
+    call list%set('someint', 1)
+    call list%set('somedouble', 2.5_dp)
+    call list%set('somestring', 'Hello World')
+    call list%print(); TEST_IERR()
+
+    call list%release(); TEST_IERR()
+
+    OUT0("Finished ParameterList_print!")
+
+  END_FORTRILINOS_UNIT_TEST(ParameterList_print)
+
+  ! ----------------------------------remove---------------------------------- !
+  FORTRILINOS_UNIT_TEST(ParameterList_remove)
+    type(ParameterList) :: list
+    OUT0("Starting ParameterList_remove!")
+
+    list = ParameterList('mylist'); TEST_IERR()
+    call list%set('test', 0)
+    TEST_ASSERT(list%is_parameter('test'))
+
+    call list%remove('test')
+    TEST_ASSERT(.not. list%is_parameter('test'))
+
+    call list%release(); TEST_IERR()
+
+    OUT0("Finished ParameterList_remove!")
+
+  END_FORTRILINOS_UNIT_TEST(ParameterList_remove)
+
+  ! -------------------------------is_parameter------------------------------- !
+  FORTRILINOS_UNIT_TEST(ParameterList_is_parameter)
+    type(ParameterList) :: list
+    OUT0("Starting ParameterList_is_parameter!")
+
+    list = ParameterList('mylist'); TEST_IERR()
+    call list%set('p1', 1)
+    call list%set('p2', 2)
+    TEST_ASSERT(list%is_parameter('p1') .and. list%is_parameter('p2'))
+    TEST_ASSERT(.not. list%is_parameter('p3'))
+
+    call list%release(); TEST_IERR()
+
+    OUT0("Finished ParameterList_is_parameter!")
+
+  END_FORTRILINOS_UNIT_TEST(ParameterList_is_parameter)
+
+  ! ---------------------------------sublist---------------------------------- !
+  FORTRILINOS_UNIT_TEST(ParameterList_sublist)
+    type(ParameterList) :: list, sub
+    OUT0("Starting ParameterList_sublist!")
+
+    list = ParameterList('mylist'); TEST_IERR()
+    sub = list%sublist('mysub'); TEST_IERR()
+    call sub%set('myint', 0)
+    TEST_ASSERT(sub%is_parameter('myint'))
+
+    call sub%release(); TEST_IERR()
+    call list%release(); TEST_IERR()
+
+    OUT0("Finished ParameterList_sublist!")
+
+  END_FORTRILINOS_UNIT_TEST(ParameterList_sublist)
+
+  ! ---------------------------------get_real--------------------------------- !
+  FORTRILINOS_UNIT_TEST(ParameterList_get_real)
+    type(ParameterList) :: list
+    real(dp) :: var
+    OUT0("Starting ParameterList_get_real!")
+
+    list = ParameterList('mylist'); TEST_IERR()
+    call list%set('myvar', 1.0_dp); TEST_IERR()
+    var = list%get_real('myvar')
+    TEST_FLOATING_EQUALITY(1.0_dp, var, epsilon(1.0_dp))
+
+    call list%release(); TEST_IERR()
+
+    OUT0("Finished ParameterList_get_real!")
+
+  END_FORTRILINOS_UNIT_TEST(ParameterList_get_real)
+
+  ! -------------------------------get_integer-------------------------------- !
+  FORTRILINOS_UNIT_TEST(ParameterList_get_integer)
+    type(ParameterList) :: list
+    integer :: var
+    OUT0("Starting ParameterList_get_integer!")
+
+    list = ParameterList('mylist'); TEST_IERR()
+    call list%set('myvar', 1); TEST_IERR()
+    var = list%get_integer('myvar')
+    TEST_EQUALITY(1, var)
+
+    call list%release(); TEST_IERR()
+
+    OUT0("Finished ParameterList_get_integer!")
+
+  END_FORTRILINOS_UNIT_TEST(ParameterList_get_integer)
+
+  ! -------------------------------get_longlong------------------------------- !
+  FORTRILINOS_UNIT_TEST(ParameterList_get_longlong)
+    type(ParameterList) :: list
+    integer, parameter :: intk = selected_int_kind(18)
+    integer(intk) :: var
+    OUT0("Starting ParameterList_get_longlong!")
+
+    list = ParameterList('mylist'); TEST_IERR()
+    call list%set('myvar', 1_intk); TEST_IERR()
+    var = list%get_longlong('myvar')
+    TEST_EQUALITY(1_intk, var)
+
+    call list%release(); TEST_IERR()
+
+    OUT0("Finished ParameterList_get_longlong!")
+
+  END_FORTRILINOS_UNIT_TEST(ParameterList_get_longlong)
+
+  ! -------------------------------get_logical-------------------------------- !
+  FORTRILINOS_UNIT_TEST(ParameterList_get_logical)
+    type(ParameterList) :: list
+    logical :: var
+    OUT0("Starting ParameterList_get_logical!")
+
+    list = ParameterList('mylist'); TEST_IERR()
+    call list%set('myvar', .true.); TEST_IERR()
+    var = list%get_logical('myvar')
+    TEST_ASSERT(var)
+
+    call list%release(); TEST_IERR()
+
+    OUT0("Finished ParameterList_get_logical!")
+
+  END_FORTRILINOS_UNIT_TEST(ParameterList_get_logical)
+
+  ! --------------------------------get_string-------------------------------- !
+  FORTRILINOS_UNIT_TEST(ParameterList_get_string)
+    type(ParameterList) :: list
+    character(kind=C_CHAR, len=:), allocatable :: var
+    OUT0("Starting ParameterList_get_string!")
+
+    list = ParameterList('mylist'); TEST_IERR()
+    call list%set('myvar', 'Test'); TEST_IERR()
+    var = list%get_string('myvar')
+    TEST_EQUALITY(var, 'Test')
+
+    deallocate(var)
+    call list%release(); TEST_IERR()
+
+    OUT0("Finished ParameterList_get_string!")
+
+  END_FORTRILINOS_UNIT_TEST(ParameterList_get_string)
+
+  ! -------------------------------get_arr_real------------------------------- !
+  FORTRILINOS_UNIT_TEST(ParameterList_get_arr_real)
+    type(ParameterList) :: list
+    real(dp), pointer :: var(:) => NULL()
+    real(dp), dimension(3) :: myvec = (/ -3.2_dp, 0.2_dp, 5.8_dp /)
+    OUT0("Starting ParameterList_get_arr_real!")
+
+    list = ParameterList('mylist'); TEST_IERR()
+    call list%set('rarr', myvec); TEST_IERR()
+    var => list%get_arr_real('rarr')
+    TEST_FLOATING_ARRAY_EQUALITY(var, myvec, epsilon(var(1)))
+
+    call list%release(); TEST_IERR()
+
+    OUT0("Finished ParameterList_get_arr_real!")
+
+  END_FORTRILINOS_UNIT_TEST(ParameterList_get_arr_real)
+
+  ! -----------------------------get_arr_integer------------------------------ !
+  FORTRILINOS_UNIT_TEST(ParameterList_get_arr_integer)
+    type(ParameterList) :: list
+    integer, pointer :: var(:) => NULL()
+    integer, dimension(3) :: myvec = (/ -3, 0, 6 /)
+    OUT0("Starting ParameterList_get_arr_integer!")
+
+    list = ParameterList('mylist'); TEST_IERR()
+    call list%set('iarr', myvec); TEST_IERR()
+    var => list%get_arr_integer('iarr')
+    TEST_ARRAY_EQUALITY(var, myvec)
+
+    call list%release(); TEST_IERR()
+
+    OUT0("Finished ParameterList_get_arr_integer!")
+
+  END_FORTRILINOS_UNIT_TEST(ParameterList_get_arr_integer)
+
+  ! -----------------------------get_arr_longlong----------------------------- !
+  FORTRILINOS_UNIT_TEST(ParameterList_get_arr_longlong)
+    type(ParameterList) :: list
+    integer, parameter :: intk = selected_int_kind(18)
+    integer(intk), pointer :: var(:) => NULL()
+    integer(intk), dimension(3) :: myvec = (/ -3, 0, 6 /)
+    OUT0("Starting ParameterList_get_arr_longlong!")
+
+    list = ParameterList('mylist'); TEST_IERR()
+    call list%set('larr', myvec); TEST_IERR()
+    var => list%get_arr_longlong('larr')
+    TEST_ARRAY_EQUALITY(var, myvec)
+
+    call list%release(); TEST_IERR()
+
+    OUT0("Finished ParameterList_get_arr_longlong!")
+
+  END_FORTRILINOS_UNIT_TEST(ParameterList_get_arr_longlong)
 
 end program test_TeuchosPList

--- a/src/tpetra/src/Tpetra_CrsGraph.i
+++ b/src/tpetra/src/Tpetra_CrsGraph.i
@@ -89,6 +89,10 @@
     const Teuchos::ArrayRCP<int>& columnIndices
 }
 
+%apply const Teuchos::ArrayView<int>& INDEX {
+    const Teuchos::ArrayView<LO>& lclColInds
+}
+
 %apply int { size_t getNumEntriesInLocalRow,
              size_t getNumAllocatedEntriesInLocalRow}
 

--- a/src/tpetra/src/swig/fortpetraFORTRAN_wrap.cxx
+++ b/src/tpetra/src/swig/fortpetraFORTRAN_wrap.cxx
@@ -8582,6 +8582,8 @@ SWIGEXPORT void _wrap_TpetraCrsGraph_getLocalRowCopy(SwigClassWrapper const *far
       SWIG_exception_impl("Tpetra::CrsGraph< LO,GO,NO >::getLocalRowCopy(Tpetra::CrsGraph< int,long long,Kokkos::Compat::KokkosSerialWrapperNode >::local_ordinal_type,Teuchos::ArrayView< Tpetra::CrsGraph< int,long long,Kokkos::Compat::KokkosSerialWrapperNode >::local_ordinal_type > const &,size_t &) const", SWIG_UnknownError, "An unknown exception occurred", return );
     }
   }
+  for (int i = 0; i < tmpview3.size(); i++)
+  tmpview3[i] += 1;
 }
 
 

--- a/src/tpetra/test/CMakeLists.txt
+++ b/src/tpetra/test/CMakeLists.txt
@@ -7,6 +7,8 @@
 ## TESTS
 ##---------------------------------------------------------------------------##
 
+INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
+
 SET(TESTS
   test_tpetra_map.F90
   test_tpetra_crsgraph.F90
@@ -14,6 +16,18 @@ SET(TESTS
   test_tpetra_multivector.F90
   test_tpetra_import_export.F90
   )
+SET(TEST_HELPERS
+  test_tpetra_crsgraph_helper.F90
+  test_tpetra_crsmatrix_helper.F90
+  test_tpetra_import_export_helper.F90
+  test_tpetra_multivector_helper.F90
+  )
+
+TRIBITS_ADD_LIBRARY(
+  fortpetra_helpers
+  SOURCES ${TEST_HELPERS}
+  DEPLIBS fortpetra
+)
 
 FOREACH(test ${TESTS})
     GET_FILENAME_COMPONENT(name ${test} NAME_WE)

--- a/src/tpetra/test/test_tpetra_crsgraph.F90
+++ b/src/tpetra/test/test_tpetra_crsgraph.F90
@@ -9,6 +9,7 @@ program test_TpetraCrsGraph
   use, intrinsic :: iso_c_binding
   use forteuchos
   use fortpetra
+  use test_tpetra_crsgraph_helper
 
   implicit none
   type(TeuchosComm) :: comm
@@ -22,40 +23,70 @@ program test_TpetraCrsGraph
   comm = TeuchosComm()
 #endif
 
+  !Fatter tests
   ADD_SUBTEST_AND_RUN(TpetraCrsGraph_ActiveFillLocal)
-  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_Parameters)
-  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_WithColmap)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_WithColMap)
   ADD_SUBTEST_AND_RUN(TpetraCrsGraph_TwoArraysESFC)
   ADD_SUBTEST_AND_RUN(TpetraCrsGraph_SortingTests)
   ADD_SUBTEST_AND_RUN(TpetraCrsGraph_EmptyFillComplete)
   ADD_SUBTEST_AND_RUN(TpetraCrsGraph_GetEntities)
 
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getComm)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getDomainMap)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getRangeMap)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getImporter)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getExporter)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_isLowerTriangular)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_isUpperTriangular)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_isLocallyIndexed)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_isGloballyIndexed)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_isStorageOptimized)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_supportsRowViews)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_description)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_replaceColMap)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_replaceDomainMapAndImporter)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_removeEmptyProcessesInPlace)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_haveGlobalConstants)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_computeGlobalConstants)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getGlobalRowCopy)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getGlobalRowView)
-!
-  call comm%release()
+  !Unit tests consistent with scripts/autogen_tests.py
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_isIdenticalTo)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_insertGlobalIndices)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_insertLocalIndices)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_removeLocalIndices)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getComm)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getRowMap)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getColMap)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getDomainMap)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getRangeMap)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getImporter)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getExporter)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getGlobalNumRows)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getGlobalNumCols)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getGlobalNumEntries)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getGlobalMaxNumRowEntries)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getNodeNumRows)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getNodeNumCols)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getNodeNumEntries)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getNodeMaxNumRowEntries)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getNumEntriesInGlobalRow)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getNumEntriesInLocalRow)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getNodeAllocationSize)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getNumAllocatedEntriesInGlobalRow)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getNumAllocatedEntriesInLocalRow)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getProfileType)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getGlobalRowCopy)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getLocalRowCopy)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getNodeRowPtrs)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getNodePackedIndices)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_hasColMap)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_isGloballyIndexed)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_isLocallyIndexed)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_isFillComplete)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_isFillActive)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_isSorted)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_isStorageOptimized)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_supportsRowViews)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_description)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_replaceColMap)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_replaceDomainMapAndImporter)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_removeEmptyProcessesInPlace)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_haveGlobalConstants)
+  ADD_SUBTEST_AND_RUN(TpetraCrsGraph_computeGlobalConstants)
+
+  ! In the wrapper but not wanting to really expose for users
+  !ADD_SUBTEST_AND_RUN(TpetraCrsGraph_setParameterList)
+  !ADD_SUBTEST_AND_RUN(TpetraCrsGraph_getValidParameters)
+  !ADD_SUBTEST_AND_RUN(TpetraCrsGraph_globalAssemble)
+
+  ! Deprecated
+  call comm%release(); TEST_IERR()
 
   TEARDOWN_TEST()
 
 contains
-
 
   ! ----------------------------- ActiveFill --------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_ActiveFillLocal)
@@ -85,7 +116,6 @@ contains
     TEST_ASSERT(graph%isFillComplete())
     TEST_THROW(call graph%insertLocalIndices(row, indices))
     TEST_THROW(call graph%removeLocalIndices(row))
-    TEST_THROW(call Graph%globalAssemble())
     TEST_THROW(call Graph%fillComplete())
 
     call Graph%resumeFill()
@@ -98,43 +128,13 @@ contains
     TEST_ASSERT((.not. graph%isFillActive()))
     TEST_ASSERT(graph%isFillComplete())
 
-    call Graph%release()
-    call Map%release()
-    call params%release()
+    call Graph%release(); TEST_IERR()
+    call Map%release(); TEST_IERR()
+    call params%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_ActiveFillLocal!")
 
   END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_ActiveFillLocal)
-
-  ! ----------------------------getValidParameters---------------------------- !
-  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_Parameters)
-    type(TpetraMap) :: Map
-    type(ParameterList) :: params
-    type(TpetraCrsGraph) :: Graph
-    integer :: row, indices(1)
-
-    OUT0("Starting TpetraCrsGraph_Parameters!")
-
-    ! create Map
-    Map = TpetraMap(TPETRA_GLOBAL_INVALID, 1, comm); TEST_IERR()
-
-    params = ParameterList("ANONYMOUS")
-    Graph = TpetraCrsGraph(Map, Map, 1_size_type, TpetraStaticProfile)
-    params = Graph%getValidParameters()
-    call Graph%setParameterList(params)
-
-    row = 1
-    indices(1) = 1
-    call Graph%insertLocalIndices(row, indices)
-    call graph%fillComplete(params)
-
-    call params%release()
-    call Graph%release()
-    call Map%release()
-
-    OUT0("Finished TpetraCrsGraph_Parameters!")
-
-  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_Parameters)
 
   ! ------------------------------- WithColMap ------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_WithColMap)
@@ -184,10 +184,10 @@ contains
     TEST_EQUALITY(tmpmap%getNodeNumElements(), cmap%getNodeNumElements())
     TEST_EQUALITY(Graph%getNumEntriesInGlobalRow(myrowind), 1_size_type)
 
-    call tmpmap%release()
-    call Graph%release()
-    call rmap%release()
-    call cmap%release()
+    call tmpmap%release(); TEST_IERR()
+    call Graph%release(); TEST_IERR()
+    call rmap%release(); TEST_IERR()
+    call cmap%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_WithColMap!")
 
@@ -228,60 +228,14 @@ contains
     TEST_EQUALITY(tmpmap%getNodeNumElements(), rmap%getNodeNumElements())
 
     deallocate(rowptr, colind)
-    call tmpmap%release()
-    call Graph%release()
-    call rmap%release()
+    call tmpmap%release(); TEST_IERR()
+    call Graph%release(); TEST_IERR()
+    call rmap%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_TwoArraysESFC!")
 
   END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_TwoArraysESFC)
 
-#if 0
-  ! TODO: Implement setAllIndices
-  ! ------------------------------ SetAllIndices ----------------------------- !
-  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_SetAllIndices)
-    type(TpetraMap) :: rmap, tmpmap
-    type(TpetraCrsGraph) :: Graph
-    integer(size_type) :: num_procs
-    integer :: num_local
-    integer(size_type), allocatable :: rowptr(:)
-    integer, allocatable :: colind(:)
-    integer(global_ordinal_type), allocatable :: indices(:)
-
-    OUT0("Starting TpetraCrsGraph_SetAllIndices!")
-    num_procs = comm%getSize()
-    !if (num_procs <= 1) return
-
-    num_local = 2
-    rmap = TpetraMap(TPETRA_GLOBAL_INVALID, num_local, comm)
-    allocate(rowptr(num_local+1))
-    allocate(colind(num_local)) ! one unknown per row
-    rowptr(1:3) = [1, 2, 3]
-    colind(1:2) = [1, 2]
-
-    Graph = TpetraCrsGraph(rmap, rmap, 0_size_type, TpetraStaticProfile)
-
-    TEST_NOTHROW(call Graph%setAllIndices(rowptr, colind))
-    TEST_ASSERT(Graph%hasColMap())
-
-    TEST_NOTHROW(call Graph%expertStaticFillComplete(rmap,rmap))
-
-    tmpmap = TpetraMap()
-    tmpmap = Graph%getRowMap()
-    TEST_EQUALITY(tmpmap%getNodeNumElements(), rmap%getNodeNumElements())
-
-    tmpmap = Graph%getColMap()
-    TEST_EQUALITY(tmpmap%getNodeNumElements(), rmap%getNodeNumElements())
-
-    deallocate(rowptr, colind)
-    call tmpmap%release()
-    call Graph%release()
-    call rmap%release()
-
-    OUT0("Finished TpetraCrsGraph_SetAllIndices!")
-
-  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_SetAllIndices)
-#endif
 
   ! ------------------------------ SortingTests ------------------------------ !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_SortingTests)
@@ -337,7 +291,7 @@ contains
     do k = kstart, kfinish
       nument = Graph%getNumEntriesInLocalRow(k)
       allocate(kinds(nument))
-      write (*,*) "Allocated", nument, "for k=", k
+      !write (*,*) "Allocated", nument, "for k=", k
       call Graph%getLocalRowCopy(k, kinds, nument); TEST_IERR()
       do kk = 2, nument
         if (kinds(kk-1) > kinds(kk)) then
@@ -400,9 +354,9 @@ contains
       deallocate(kinds)
     end do
 
-    call Graph%release()
-    call map%release()
-    call params%release()
+    call Graph%release(); TEST_IERR()
+    call map%release(); TEST_IERR()
+    call params%release(); TEST_IERR()
     OUT0("Finished TpetraCrsGraph_SortingTests!")
 
   END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_SortingTests)
@@ -423,9 +377,9 @@ contains
     ! (and therefore, without allocating)
     Graph = TpetraCrsGraph(map, 1_size_type, TpetraStaticProfile)
     call Graph%fillComplete()
-    call Graph%release()
+    call Graph%release(); TEST_IERR()
 
-    call map%release()
+    call map%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_EmptyFillComplete!")
 
@@ -493,46 +447,296 @@ contains
     i_LO = Graph%getNodeMaxNumRowEntries()
     TEST_EQUALITY(i_LO, 1_size_type)
 
-    call Graph%release()
-    call rmap%release()
-    call cmap%release()
+    call Graph%release(); TEST_IERR()
+    call rmap%release(); TEST_IERR()
+    call cmap%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_GetEntities!")
 
   END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_GetEntities)
 
-#if 0
+  ! ------------------------------isIdenticalTo------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isIdenticalTo)
+    type(TpetraMap) :: Map
+    type(TpetraCrsGraph) :: Graph1, Graph2
+    integer(global_ordinal_type) :: num_global
+    integer(size_type), parameter :: izero=0, ione=1
+    logical :: fresult
+
+    OUT0("Starting TpetraCrsGraph_isIdenticalTo!")
+
+    ! create Map and Graph
+    num_global = 4*comm%getSize()
+    Map = TpetraMap(num_global, comm); TEST_IERR()
+    Graph1 = TpetraCrsGraph(Map, Map, ione, TpetraStaticProfile)
+    Graph2 = TpetraCrsGraph(Map, Map, ione, TpetraStaticProfile)
+
+    call Graph1%fillComplete()
+    call Graph2%fillComplete()
+
+    TEST_ASSERT(Graph1%isIdenticalTo(Graph2))
+
+    call Graph1%release(); TEST_IERR()
+    call Graph2%release(); TEST_IERR()
+    call Map%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_isIdenticalTo!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isIdenticalTo)
+
+  ! ----------------------------insertLocalIndices---------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_insertLocalIndices)
+    type(TpetraCrsGraph) :: Graph
+    type(TpetraMap) :: rowMap, colMap
+    integer(int_type) :: lclNumRows, lclNumCols, lclRow
+    integer(global_ordinal_type) gblNumRows
+    integer(int_type) :: numProcs
+    integer(int_type), dimension(:), allocatable :: lclColInds
+    integer(int_type), dimension(:), allocatable :: curLclColInds
+    integer(size_type), parameter :: max_entries_per_row=3
+    integer(size_type) :: numEnt=0
+
+    OUT0("Starting TpetraCrsGraph_insertLocalIndices!")
+
+    numProcs = comm%getSize()
+    lclNumRows = 10
+    gblNumRows = lclNumRows * numProcs
+    rowMap = TpetraMap(gblNumRows, lclNumRows, comm)
+    lclNumCols = lclNumRows
+    colMap = rowMap
+    Graph = TpetraCrsGraph(rowMap, colMap, max_entries_per_row, TpetraStaticProfile)
+
+    allocate(lclColInds(2))
+
+    do lclRow = 1, lclNumRows
+      lclColInds(1) = 1 + modulo(lclRow + 0, lclNumCols)
+      lclColInds(2) = 1 + modulo(lclRow + 1, lclNumCols)
+      TEST_NOTHROW(call Graph%insertLocalIndices(lclRow, lclColInds))
+    end do
+
+    ! Make the arrays bigger than necessary, just to make sure that
+    ! the methods behave correctly.
+    allocate(curLclColInds(5))
+
+    do lclRow = 1, lclNumRows
+      TEST_NOTHROW(call Graph%getLocalRowCopy(lclRow, curLclColInds, numEnt))
+      TEST_EQUALITY(int(numEnt), 2)
+
+      TEST_EQUALITY(curLclColInds(1), 1 + modulo(lclRow + 0, lclNumCols));
+      TEST_EQUALITY(curLclColInds(2), 1 + modulo(lclRow + 1, lclNumCols));
+    enddo
+
+    call Graph%release(); TEST_IERR()
+    call rowMap%release(); TEST_IERR()
+    call colMap%release(); TEST_IERR()
+    deallocate(lclColInds)
+    deallocate(curLclColInds)
+
+    OUT0("Finished TpetraCrsGraph_insertLocalIndices!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_insertLocalIndices)
+
+  ! ----------------------------insertGlobalIndices---------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_insertGlobalIndices)
+    type(TpetraCrsGraph) :: Graph
+    type(TpetraMap) :: rmap
+    integer :: irow, nnz
+    integer(size_type) :: nument;
+    integer(global_ordinal_type), allocatable :: cols_expected(:)
+    integer(global_ordinal_type), allocatable :: cols(:)
+    integer(global_ordinal_type) :: gblrow
+
+    OUT0("Starting TpetraCrsGraph_insertGlobalIndices!")
+
+    ! Duplicate Tpetra_CrsGraph_CreateTestGraph_A here because
+    ! we want insertGlobalIndices to appear explicitly.
+    rmap = TpetraMap(Tpetra_GLOBAL_INVALID, test_graph_num_row(), comm)
+    Graph = TpetraCrsGraph(rmap, test_graph_max_entries_per_row(), TpetraStaticProfile)
+
+    do irow=1,test_graph_num_row()
+      call Tpetra_CrsGraph_GetTestGraphRow_A(comm, irow, gblrow, cols_expected, nnz)
+      call Graph%insertGlobalIndices(gblrow, cols_expected)
+      deallocate(cols_expected)
+    enddo
+
+    !---------------------------------------------------------------
+    ! CHECK results
+    !---------------------------------------------------------------
+    do irow=1,test_graph_num_row()
+      call Tpetra_CrsGraph_GetTestGraphRow_A(comm, irow, gblrow, cols_expected, nnz)
+      allocate(cols(nnz))
+      call Graph%getGlobalRowCopy(gblrow, cols, nument)
+      TEST_EQUALITY(nnz, int(nument))
+      TEST_ARRAY_EQUALITY(cols, cols_expected)
+      deallocate(cols_expected)
+      deallocate(cols)
+    enddo
+
+    call Graph%release(); TEST_IERR()
+    call rmap%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_insertGlobalIndices!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_insertGlobalIndices)
+
+  ! ----------------------------removeLocalIndices---------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_removeLocalIndices)
+    type(TpetraCrsGraph) :: Graph
+    type(TpetraMap) :: rowMap, colMap
+    integer(int_type) :: lclNumRows, lclNumCols, lclRow
+    integer(global_ordinal_type) gblNumRows
+    integer(int_type) :: numProcs
+    integer(int_type), dimension(:), allocatable :: lclColInds
+    integer(int_type), dimension(:), allocatable :: curLclColInds
+    integer(size_type), parameter :: max_entries_per_row=3
+    integer(size_type) :: numEnt=0
+
+    OUT0("Starting TpetraCrsGraph_removeLocalIndices!")
+
+    numProcs = comm%getSize()
+    lclNumRows = 10
+    gblNumRows = lclNumRows * numProcs
+    rowMap = TpetraMap(gblNumRows, lclNumRows, comm)
+    lclNumCols = lclNumRows
+    colMap = rowMap
+    Graph = TpetraCrsGraph(rowMap, colMap, max_entries_per_row, TpetraStaticProfile)
+
+    allocate(lclColInds(2))
+
+    do lclRow = 1, lclNumRows
+      lclColInds(1) = 1 + modulo(lclRow + 0, lclNumCols)
+      lclColInds(2) = 1 + modulo(lclRow + 1, lclNumCols)
+      TEST_NOTHROW(call Graph%insertLocalIndices(lclRow, lclColInds))
+    end do
+
+    ! Now remove just row 5
+    lclRow = 5
+    TEST_NOTHROW(call Graph%removeLocalIndices(lclRow))
+
+    ! Make the arrays bigger than necessary, just to make sure that
+    ! the methods behave correctly.
+    allocate(curLclColInds(5))
+
+    do lclRow = 1, lclNumRows
+      TEST_NOTHROW(call Graph%getLocalRowCopy(lclRow, curLclColInds, numEnt))
+
+      ! We should have this row only to be empty
+      if(lclRow .EQ. 5) then
+        TEST_EQUALITY(int(numEnt), 0)
+      else
+        TEST_EQUALITY(int(numEnt), 2)
+
+      TEST_EQUALITY(curLclColInds(1), 1 + modulo(lclRow + 0, lclNumCols));
+      TEST_EQUALITY(curLclColInds(2), 1 + modulo(lclRow + 1, lclNumCols));
+      endif
+
+    enddo
+
+    call Graph%release(); TEST_IERR()
+    call rowMap%release(); TEST_IERR()
+    call colMap%release(); TEST_IERR()
+    deallocate(lclColInds)
+    deallocate(curLclColInds)
+
+    OUT0("Finished TpetraCrsGraph_removeLocalIndices!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_removeLocalIndices)
+
   ! ---------------------------------getComm---------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getComm)
-    type(TpetraCrsGraph) :: Obj
+    type(TpetraCrsGraph) :: Graph
+    type(TeuchosComm) :: gcomm
+
     OUT0("Starting TpetraCrsGraph_getComm!")
 
-    success = .false.
+    call Tpetra_CrsGraph_CreateBasic(comm, Graph)
 
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !fresult = Obj%getComm(); TEST_IERR()
+    gcomm = Graph%getComm(); TEST_IERR()
 
-    !call Obj%release(); TEST_IERR()
+    ! We only test the comm returned has the same rank and size.  More
+    ! comprehensive testing is (assumed to be) done in Teuchos itself.
+    TEST_ASSERT(gcomm%getRank() == comm%getRank())
+    TEST_ASSERT(gcomm%getSize() == comm%getSize())
 
-    write(*,*) 'TpetraCrsGraph_getComm: Test not yet implemented'
+    call gcomm%release(); TEST_IERR()
+    call Graph%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_getComm!")
 
   END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getComm)
 
+  ! --------------------------------getRowMap--------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getRowMap)
+    type(TpetraMap) :: rmap, tmpmap
+    type(TpetraCrsGraph) :: Graph
+
+    OUT0("Starting TpetraCrsGraph_getRowMap!")
+
+    ! Consistent with Tpetra_CrsGraph_CreateTestGraph_B
+    rmap = TpetraMap(TPETRA_GLOBAL_INVALID, test_graph_num_local(), comm)
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm,Graph)
+    call Graph%fillComplete()
+
+    tmpmap = Graph%getRowMap()
+
+    TEST_EQUALITY(tmpmap%getNodeNumElements(), rmap%getNodeNumElements())
+    TEST_ASSERT(tmpmap%isSameAs(rmap))
+
+    call tmpmap%release(); TEST_IERR()
+    call rmap%release(); TEST_IERR()
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getRowMap!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getRowMap)
+
+  ! --------------------------------getColMap--------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getColMap)
+    type(TpetraMap) :: cmap, tmpmap
+    type(TpetraCrsGraph) :: Graph
+
+    OUT0("Starting TpetraCrsGraph_getColMap!")
+
+    ! Consistent with Tpetra_CrsGraph_CreateTestGraph_B
+    cmap = TpetraMap(TPETRA_GLOBAL_INVALID, test_graph_num_local(), comm)
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
+    tmpmap = Graph%getColMap()
+
+    TEST_EQUALITY(tmpmap%getNodeNumElements(), cmap%getNodeNumElements())
+    TEST_ASSERT(tmpmap%isSameAs(cmap))
+
+    call tmpmap%release(); TEST_IERR()
+    call Graph%release(); TEST_IERR();
+    call cmap%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getColMap!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getColMap)
+
   ! -------------------------------getDomainMap------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getDomainMap)
-    type(TpetraCrsGraph) :: Obj
+    type(TpetraMap) :: Map, tmpmap
+    type(TpetraCrsGraph) :: Graph
+    integer(global_ordinal_type) :: num_global
+
     OUT0("Starting TpetraCrsGraph_getDomainMap!")
 
-    success = .false.
+    ! create Map and Graph
+    num_global = test_graph_num_local()*comm%getSize()
+    ! Consistent with Tpetra_CrsGraph_CreateTestGraph_B
+    Map = TpetraMap(num_global, comm); TEST_IERR()
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
 
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !fresult = Obj%getDomainMap(); TEST_IERR()
+    tmpmap = Graph%getDomainMap(); TEST_IERR()
+    TEST_ASSERT(tmpmap%isSameAs(Map))
 
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsGraph_getDomainMap: Test not yet implemented'
+    call tmpmap%release(); TEST_IERR()
+    call Graph%release(); TEST_IERR()
+    call Map%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_getDomainMap!")
 
@@ -540,17 +744,26 @@ contains
 
   ! -------------------------------getRangeMap-------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getRangeMap)
-    type(TpetraCrsGraph) :: Obj
+    type(TpetraMap) :: Map, tmpmap
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type), parameter :: izero=0, ione=1
+    integer(global_ordinal_type) :: num_global
+
     OUT0("Starting TpetraCrsGraph_getRangeMap!")
 
-    success = .false.
+    ! create Map and Graph
+    num_global = test_graph_num_local()*comm%getSize()
+    ! Consistent with Tpetra_CrsGraph_CreateTestGraph_B
+    Map = TpetraMap(num_global, comm); TEST_IERR()
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
 
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !fresult = Obj%getRangeMap(); TEST_IERR()
+    tmpmap = Graph%getRangeMap(); TEST_IERR()
+    TEST_ASSERT(tmpmap%isSameAs(Map))
 
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsGraph_getRangeMap: Test not yet implemented'
+    call tmpmap%release(); TEST_IERR()
+    call Graph%release(); TEST_IERR()
+    call Map%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_getRangeMap!")
 
@@ -558,17 +771,32 @@ contains
 
   ! -------------------------------getImporter-------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getImporter)
-    type(TpetraCrsGraph) :: Obj
+    type(TpetraMap) :: rmap, cmap, imprmap, impcmap
+    type(TpetraCrsGraph) :: Graph
+    type(TpetraImport) :: importer
+    integer(size_type) :: num_ent_per_row
+
     OUT0("Starting TpetraCrsGraph_getImporter!")
 
-    success = .false.
+    rmap = TpetraMap(TPETRA_GLOBAL_INVALID, test_graph_num_local(), comm); TEST_IERR()
+    cmap = TpetraMap(TPETRA_GLOBAL_INVALID, 2*test_graph_num_local(), comm); TEST_IERR()
+    ! must allocate enough for all submitted indices.
+    num_ent_per_row = 2
+    Graph = TpetraCrsGraph(rmap, cmap, num_ent_per_row)
+    call Graph%fillComplete()
 
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !fresult = Obj%getImporter(); TEST_IERR()
+    importer = Graph%getImporter()
+    imprmap = importer%getSourceMap()
+    TEST_ASSERT(rmap%isSameAs(imprmap))
+    impcmap = importer%getTargetMap()
+    TEST_ASSERT(cmap%isSameAs(impcmap))
 
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsGraph_getImporter: Test not yet implemented'
+    call imprmap%release(); TEST_IERR()
+    call impcmap%release(); TEST_IERR()
+    call importer%release(); TEST_IERR()
+    call Graph%release(); TEST_IERR()
+    call rmap%release(); TEST_IERR()
+    call cmap%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_getImporter!")
 
@@ -576,71 +804,477 @@ contains
 
   ! -------------------------------getExporter-------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getExporter)
-    type(TpetraCrsGraph) :: Obj
+    type(TpetraMap) :: rmap, cmap, expmap
+    type(TpetraCrsGraph) :: Graph
+    type(TpetraExport) :: exporter
+    integer(size_type) :: num_ent_per_row
+
     OUT0("Starting TpetraCrsGraph_getExporter!")
 
-    success = .false.
+    rmap = TpetraMap(TPETRA_GLOBAL_INVALID, test_graph_num_local(), comm); TEST_IERR()
+    cmap = TpetraMap(TPETRA_GLOBAL_INVALID, 2*test_graph_num_local(), comm); TEST_IERR()
+    ! must allocate enough for all submitted indices.
+    num_ent_per_row = 2
+    Graph = TpetraCrsGraph(rmap, cmap, num_ent_per_row)
 
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !fresult = Obj%getExporter(); TEST_IERR()
+    ! make range map different so exporter will exist
+    call Graph%fillComplete(rmap, cmap)
 
-    !call Obj%release(); TEST_IERR()
+    exporter = Graph%getExporter()
+    expmap = exporter%getSourceMap()
+    TEST_ASSERT(rmap%isSameAs(expmap))
 
-    write(*,*) 'TpetraCrsGraph_getExporter: Test not yet implemented'
+    call exporter%release(); TEST_IERR()
+    call Graph%release(); TEST_IERR()
+    call rmap%release(); TEST_IERR()
+    call cmap%release(); TEST_IERR()
+    call expmap%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_getExporter!")
 
   END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getExporter)
 
-  ! ----------------------------isLowerTriangular----------------------------- !
-  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isLowerTriangular)
-    type(TpetraCrsGraph) :: Obj
-    OUT0("Starting TpetraCrsGraph_isLowerTriangular!")
+  ! -----------------------------getGlobalNumRows----------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getGlobalNumRows)
+    type(TpetraMap) :: rmap, cmap
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type) :: num_ent_per_row, ires
+    integer :: num_local
+    integer :: commsize
 
-    success = .false.
+    OUT0("Starting TpetraCrsGraph_getGlobalNumRows!")
 
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !fresult = Obj%isLowerTriangular(); TEST_IERR()
+    num_local = 1
+    rmap = TpetraMap(TPETRA_GLOBAL_INVALID, num_local, comm); TEST_IERR()
+    cmap = TpetraMap(TPETRA_GLOBAL_INVALID, num_local, comm); TEST_IERR()
+    ! must allocate enough for all submitted indices.
+    num_ent_per_row = 2
+    Graph = TpetraCrsGraph(rmap, cmap, num_ent_per_row, TpetraStaticProfile)
 
-    !call Obj%release(); TEST_IERR()
+    commsize = comm%getSize()
+    ires = Graph%getGlobalNumRows()
+    TEST_EQUALITY(ires, int(commsize,size_type))
 
-    write(*,*) 'TpetraCrsGraph_isLowerTriangular: Test not yet implemented'
+    call Graph%release(); TEST_IERR()
+    call rmap%release(); TEST_IERR()
+    call cmap%release(); TEST_IERR()
 
-    OUT0("Finished TpetraCrsGraph_isLowerTriangular!")
+    OUT0("Finished TpetraCrsGraph_getGlobalNumRows!")
 
-  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isLowerTriangular)
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getGlobalNumRows)
 
-  ! ----------------------------isUpperTriangular----------------------------- !
-  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isUpperTriangular)
-    type(TpetraCrsGraph) :: Obj
-    OUT0("Starting TpetraCrsGraph_isUpperTriangular!")
+  ! -----------------------------getGlobalNumCols----------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getGlobalNumCols)
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type) :: ires
 
-    success = .false.
+    OUT0("Starting TpetraCrsGraph_getGlobalNumCols!")
 
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !fresult = Obj%isUpperTriangular(); TEST_IERR()
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
 
-    !call Obj%release(); TEST_IERR()
+    ires = Graph%getGlobalNumCols()
+    TEST_EQUALITY(ires, int(test_graph_num_local()*comm%getSize(),size_type))
 
-    write(*,*) 'TpetraCrsGraph_isUpperTriangular: Test not yet implemented'
+    call Graph%release(); TEST_IERR()
 
-    OUT0("Finished TpetraCrsGraph_isUpperTriangular!")
+    OUT0("Finished TpetraCrsGraph_getGlobalNumCols!")
 
-  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isUpperTriangular)
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getGlobalNumCols)
+
+  ! ---------------------------getGlobalNumEntries---------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getGlobalNumEntries)
+    type(TpetraMap) :: rmap, cmap
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type) :: ires
+
+    OUT0("Starting TpetraCrsGraph_getGlobalNumEntries!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
+
+    ires = Graph%getGlobalNumEntries()
+    ! match num_ent_per_row in CreateTestGraph
+    TEST_EQUALITY(ires, int(2*comm%getSize(),size_type))
+
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getGlobalNumEntries!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getGlobalNumEntries)
+
+  ! ------------------------getGlobalMaxNumRowEntries------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getGlobalMaxNumRowEntries)
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type) ::  ires
+
+    OUT0("Starting TpetraCrsGraph_getGlobalMaxNumRowEntries!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
+
+    ires = Graph%getGlobalMaxNumRowEntries()
+    ! match num_ent_per_row in CreateTestGraph
+    TEST_EQUALITY(ires, int(2,size_type))
+
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getGlobalMaxNumRowEntries!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getGlobalMaxNumRowEntries)
+
+  ! ------------------------------getNodeNumRows------------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNodeNumRows)
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type) ::  ires
+
+    OUT0("Starting TpetraCrsGraph_getNodeNumRows!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
+
+    ires = Graph%getNodeNumRows()
+    TEST_EQUALITY(ires, int(test_graph_num_local(), size_type))
+
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getNodeNumRows!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNodeNumRows)
+
+  ! ------------------------------getNodeNumCols------------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNodeNumCols)
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type) :: ires
+
+    OUT0("Starting TpetraCrsGraph_getNodeNumCols!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
+
+    ires = Graph%getNodeNumCols()
+    TEST_EQUALITY(ires, int(test_graph_num_local(), size_type))
+
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getNodeNumCols!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNodeNumCols)
+
+  ! ----------------------------getNodeNumEntries----------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNodeNumEntries)
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type) :: ires
+
+    OUT0("Starting TpetraCrsGraph_getNodeNumEntries!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
+
+    ires = Graph%getNodeNumEntries()
+    TEST_EQUALITY(ires, int(2,size_type))
+
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getNodeNumEntries!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNodeNumEntries)
+
+  ! -------------------------getNodeMaxNumRowEntries-------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNodeMaxNumRowEntries)
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type) :: ires
+
+    OUT0("Starting TpetraCrsGraph_getNodeMaxNumRowEntries!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
+
+    ires = Graph%getNodeMaxNumRowEntries()
+    TEST_EQUALITY(ires, int(2,size_type))
+
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getNodeMaxNumRowEntries!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNodeMaxNumRowEntries)
+
+  ! -------------------------getNumEntriesInGlobalRow------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNumEntriesInGlobalRow)
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type) :: ires
+    type(TpetraMap) :: rmap
+    integer(global_ordinal_type) :: myrowind
+    integer :: lclrow
+
+    OUT0("Starting TpetraCrsGraph_getNumEntriesInGlobalRow!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
+
+    lclrow = 1
+    rmap = Graph%getRowMap()
+    myrowind = rmap%getGlobalElement(lclrow);
+    ires = Graph%getNumEntriesInGlobalRow(myrowind)
+    TEST_EQUALITY(ires, int(2,size_type))
+
+    call Graph%release(); TEST_IERR()
+    call rmap%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getNumEntriesInGlobalRow!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNumEntriesInGlobalRow)
+
+  ! -------------------------getNumEntriesInLocalRow-------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNumEntriesInLocalRow)
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type) :: ires
+    integer :: lclrow
+
+    OUT0("Starting TpetraCrsGraph_getNumEntriesInLocalRow!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
+
+    lclrow = 1
+    ires = Graph%getNumEntriesInLocalRow(lclrow)
+    TEST_EQUALITY(ires, int(2,size_type))
+
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getNumEntriesInLocalRow!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNumEntriesInLocalRow)
+
+  ! --------------------------getNodeAllocationSize--------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNodeAllocationSize)
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type) :: ires
+
+    OUT0("Starting TpetraCrsGraph_getNodeAllocationSize!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
+
+    ires = Graph%getNodeAllocationSize()
+    ! match num_ent_per_row in CreateTestGraph
+    TEST_EQUALITY(ires, int(2,size_type))
+
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getNodeAllocationSize!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNodeAllocationSize)
+
+  ! --------------------getNumAllocatedEntriesInGlobalRow--------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNumAllocatedEntriesInGlobalRow)
+    type(TpetraMap) :: rmap
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type) :: ires
+    integer(global_ordinal_type) :: myrowind
+    integer :: lclrow
+
+    OUT0("Starting TpetraCrsGraph_getNumAllocatedEntriesInGlobalRow!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
+
+    lclrow = 1
+    rmap = Graph%getRowMap()
+    myrowind = rmap%getGlobalElement(lclrow);
+    ires = Graph%getNumAllocatedEntriesInGlobalRow(myrowind)
+    TEST_EQUALITY(ires, int(2,size_type))
+
+    call Graph%release(); TEST_IERR()
+    call rmap%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getNumAllocatedEntriesInGlobalRow!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNumAllocatedEntriesInGlobalRow)
+
+  ! ---------------------getNumAllocatedEntriesInLocalRow--------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNumAllocatedEntriesInLocalRow)
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type) :: ires
+    integer :: lclrow
+
+    OUT0("Starting TpetraCrsGraph_getNumAllocatedEntriesInLocalRow!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
+
+    lclrow = 1
+    ires = Graph%getNumAllocatedEntriesInLocalRow(lclrow)
+    TEST_EQUALITY(ires, int(2,size_type))
+
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getNumAllocatedEntriesInLocalRow!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNumAllocatedEntriesInLocalRow)
+
+  ! ------------------------------getProfileType------------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getProfileType)
+    type(TpetraCrsGraph) :: Graph
+
+    OUT0("Starting TpetraCrsGraph_getProfileType!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+
+    TEST_ASSERT(graph%getProfileType() == TpetraStaticProfile)
+
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getProfileType!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getProfileType)
+
+  ! -----------------------------getGlobalRowCopy----------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getGlobalRowCopy)
+    type(TpetraCrsGraph) :: Graph
+    integer :: irow, nnz
+    integer(size_type) :: nument;
+    integer(global_ordinal_type), allocatable :: cols_expected(:)
+    integer(global_ordinal_type), allocatable :: cols(:)
+    integer(global_ordinal_type) :: gblrow
+
+    OUT0("Starting TpetraCrsGraph_getGlobalRowCopy!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_A(comm, Graph)
+    do irow=1,test_graph_num_row()
+      call Tpetra_CrsGraph_GetTestGraphRow_A(comm, irow, gblrow, cols_expected, nnz)
+      allocate(cols(nnz))
+      call Graph%getGlobalRowCopy(gblrow, cols, nument)
+      TEST_EQUALITY(nnz, int(nument))
+      TEST_ARRAY_EQUALITY(cols, cols_expected)
+      deallocate(cols_expected)
+      deallocate(cols)
+    enddo
+
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getGlobalRowCopy!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getGlobalRowCopy)
+
+  ! -----------------------------getLocalRowCopy------------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getLocalRowCopy)
+    type(TpetraCrsGraph) :: Graph
+    type(TpetraMap) :: rowMap, colMap
+    integer(int_type) :: lclNumRows, lclNumCols, lclRow
+    integer(global_ordinal_type) gblNumRows
+    integer(int_type) :: numProcs
+    integer(int_type), dimension(:), allocatable :: lclColInds
+    integer(int_type), dimension(:), allocatable :: curLclColInds
+    integer(size_type), parameter :: max_entries_per_row=3
+    integer(size_type) :: numEnt=0
+
+    OUT0("Finished TpetraCrsGraph_insertLocalIndices!")
+
+    numProcs = comm%getSize()
+    lclNumRows = 10
+    gblNumRows = lclNumRows * numProcs
+    rowMap = TpetraMap(gblNumRows, lclNumRows, comm)
+    lclNumCols = lclNumRows
+    colMap = rowMap
+    Graph = TpetraCrsGraph(rowMap, colMap, max_entries_per_row, TpetraStaticProfile)
+
+    allocate(lclColInds(2))
+
+    do lclRow = 1, lclNumRows
+      lclColInds(1) = 1 + modulo(lclRow + 0, lclNumCols)
+      lclColInds(2) = 1 + modulo(lclRow + 1, lclNumCols)
+      TEST_NOTHROW(call Graph%insertLocalIndices(lclRow, lclColInds))
+    end do
+
+    ! Make the arrays bigger than necessary, just to make sure that
+    ! the methods behave correctly.
+    allocate(curLclColInds(5))
+
+    do lclRow = 1, lclNumRows
+      TEST_NOTHROW(call Graph%getLocalRowCopy(lclRow, curLclColInds, numEnt))
+      TEST_EQUALITY(int(numEnt), 2)
+
+      TEST_EQUALITY(curLclColInds(1), 1 + modulo(lclRow + 0, lclNumCols));
+      TEST_EQUALITY(curLclColInds(2), 1 + modulo(lclRow + 1, lclNumCols));
+    enddo
+
+    call Graph%release(); TEST_IERR()
+    call rowMap%release(); TEST_IERR()
+    call colMap%release(); TEST_IERR()
+    deallocate(lclColInds)
+    deallocate(curLclColInds)
+
+    OUT0("Finished TpetraCrsGraph_getLocalRowCopy!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getLocalRowCopy)
+
+  ! ------------------------------getNodeRowPtrs------------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNodeRowPtrs)
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type), allocatable :: rowpointers(:)
+
+    OUT0("Starting TpetraCrsGraph_getNodeRowPtrs!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+
+    allocate(rowpointers(1))
+    TEST_THROW(call Graph%getNodeRowPtrs(rowpointers(:)))
+
+    deallocate(rowpointers)
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getNodeRowPtrs!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNodeRowPtrs)
+
+  ! ---------------------------getNodePackedIndices--------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNodePackedIndices)
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type), allocatable :: columnindices(:)
+
+    OUT0("Starting TpetraCrsGraph_getNodePackedIndices!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+
+    allocate(columnindices(1))
+    TEST_THROW(call Graph%getNodePackedIndices(columnindices(:)))
+
+    deallocate(columnindices)
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_getNodePackedIndices!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getNodePackedIndices)
+
+  ! --------------------------------hasColMap--------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_hasColMap)
+    type(TpetraCrsGraph) :: Graph
+
+    OUT0("Starting TpetraCrsGraph_hasColMap!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+
+    TEST_ASSERT(Graph%hasColMap())
+
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_hasColMap!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_hasColMap)
 
   ! -----------------------------isLocallyIndexed----------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isLocallyIndexed)
-    type(TpetraCrsGraph) :: Obj
+    type(TpetraCrsGraph) :: Graph
+
     OUT0("Starting TpetraCrsGraph_isLocallyIndexed!")
 
-    success = .false.
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()
 
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !fresult = Obj%isLocallyIndexed(); TEST_IERR()
+    TEST_ASSERT(Graph%isLocallyIndexed())
 
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsGraph_isLocallyIndexed: Test not yet implemented'
+    call Graph%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_isLocallyIndexed!")
 
@@ -648,35 +1282,92 @@ contains
 
   ! ----------------------------isGloballyIndexed----------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isGloballyIndexed)
-    type(TpetraCrsGraph) :: Obj
+    type(TpetraCrsGraph) :: Graph
+
     OUT0("Starting TpetraCrsGraph_isGloballyIndexed!")
 
-    success = .false.
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
 
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !fresult = Obj%isGloballyIndexed(); TEST_IERR()
+    TEST_ASSERT(Graph%isGloballyIndexed())
 
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsGraph_isGloballyIndexed: Test not yet implemented'
+    call Graph%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_isGloballyIndexed!")
 
   END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isGloballyIndexed)
 
+  ! ------------------------------isFillComplete------------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isFillComplete)
+    type(TpetraCrsGraph) :: Graph
+
+    OUT0("Starting TpetraCrsGraph_isFillComplete!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+
+    TEST_ASSERT(.not. Graph%isFillComplete())
+    call Graph%fillComplete()
+    TEST_ASSERT(Graph%isFillComplete())
+
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_isFillComplete!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isFillComplete)
+
+  ! -------------------------------isFillActive------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isFillActive)
+    type(TpetraCrsGraph) :: Graph
+
+    OUT0("Starting TpetraCrsGraph_isFillActive!")
+
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+
+    TEST_ASSERT(Graph%isFillActive())
+    call Graph%fillComplete()
+    TEST_ASSERT(.not. Graph%isFillActive())
+
+    call Graph%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_isFillActive!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isFillActive)
+
+  ! ---------------------------------isSorted--------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isSorted)
+    type(TpetraMap) :: map
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type) :: nument
+    integer :: num_local
+
+    OUT0("Starting TpetraCrsGraph_isSorted!")
+
+    ! create a Map
+    num_local = 10;
+    map = TpetraMap(TPETRA_GLOBAL_INVALID, num_local, comm)
+
+    nument = 4
+    Graph = TpetraCrsGraph(map, map, nument); TEST_IERR()
+    TEST_ASSERT(graph%isSorted())
+
+    call Graph%release(); TEST_IERR()
+    call map%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsGraph_isSorted!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isSorted)
+
   ! ----------------------------isStorageOptimized---------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_isStorageOptimized)
-    type(TpetraCrsGraph) :: Obj
+    type(TpetraCrsGraph) :: Graph
+
     OUT0("Starting TpetraCrsGraph_isStorageOptimized!")
 
-    success = .false.
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    TEST_ASSERT(.not. Graph%isStorageOptimized())
+    call Graph%fillComplete()
+    TEST_ASSERT(Graph%isStorageOptimized())
 
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !fresult = Obj%isStorageOptimized(); TEST_IERR()
-
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsGraph_isStorageOptimized: Test not yet implemented'
+    call Graph%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_isStorageOptimized!")
 
@@ -684,17 +1375,15 @@ contains
 
   ! -----------------------------supportsRowViews----------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_supportsRowViews)
-    type(TpetraCrsGraph) :: Obj
+    type(TpetraCrsGraph) :: Graph
+
     OUT0("Starting TpetraCrsGraph_supportsRowViews!")
 
-    success = .false.
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
 
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !fresult = Obj%supportsRowViews(); TEST_IERR()
+    TEST_ASSERT(Graph%supportsRowViews())
 
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsGraph_supportsRowViews: Test not yet implemented'
+    call Graph%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_supportsRowViews!")
 
@@ -702,17 +1391,16 @@ contains
 
   ! -------------------------------description-------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_description)
-    type(TpetraCrsGraph) :: Obj
+    type(TpetraCrsGraph) :: Graph
+    character(kind=C_CHAR) :: fresult
+
     OUT0("Starting TpetraCrsGraph_description!")
 
-    success = .false.
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
 
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !fresult = Obj%description(); TEST_IERR()
+    TEST_NOTHROW(fresult = Graph%description())
 
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsGraph_description: Test not yet implemented'
+    call Graph%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_description!")
 
@@ -720,20 +1408,25 @@ contains
 
   ! ------------------------------replaceColMap------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_replaceColMap)
-    type(TpetraCrsGraph) :: Obj
-    type(TpetraMap) :: newcolmap
+    type(TpetraMap) :: Map, newcolmap
+    type(TpetraExport) :: fresult
+    type(TpetraCrsGraph) :: Graph
+    integer(global_ordinal_type) :: num_global
+
     OUT0("Starting TpetraCrsGraph_replaceColMap!")
 
-    success = .false.
+    num_global = 4*comm%getSize()
+    Map = TpetraMap(num_global, comm); TEST_IERR()
+    Graph = TpetraCrsGraph(Map, Map, 1_size_type, TpetraStaticProfile)
 
-    !newcolmap = TpetraMap(); TEST_IERR()
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !call Obj%replaceColMap(newcolmap); TEST_IERR()
+    ! Make a new colmap
+    newcolmap = TpetraMap(num_global, comm); TEST_IERR()
 
-    !call newcolmap%release(); TEST_IERR()
-    !call Obj%release(); TEST_IERR()
+    TEST_NOTHROW(call Graph%replaceColMap(newcolmap))
 
-    write(*,*) 'TpetraCrsGraph_replaceColMap: Test not yet implemented'
+    call Graph%release(); TEST_IERR()
+    call Map%release(); TEST_IERR()
+    call newcolmap%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_replaceColMap!")
 
@@ -741,23 +1434,33 @@ contains
 
   ! -----------------------replaceDomainMapAndImporter------------------------ !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_replaceDomainMapAndImporter)
-    type(TpetraCrsGraph) :: Obj
-    type(TpetraMap) :: newdomainmap
+    type(TpetraMap) :: Map, newdomainmap, newcolmap
     type(TpetraImport) :: newimporter
+    type(TpetraExport) :: fresult
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type), parameter :: izero=0, ione=1
+    integer(global_ordinal_type) :: num_global
+
     OUT0("Starting TpetraCrsGraph_replaceDomainMapAndImporter!")
 
-    success = .false.
+    num_global = 4*comm%getSize()
+    Map = TpetraMap(num_global, comm); TEST_IERR()
+    Graph = TpetraCrsGraph(Map, Map, izero, TpetraStaticProfile)
+    call Graph%fillComplete()     ! Needed for gloStaticstants
 
-    !newdomainmap = TpetraMap(); TEST_IERR()
-    !newimporter = TpetraImport(); TEST_IERR()
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !call Obj%replaceDomainMapAndImporter(newdomainmap, newimporter); TEST_IERR()
+    ! Make a new colmap
+    num_global = 5*comm%getSize()
+    newdomainmap = TpetraMap(num_global, comm); TEST_IERR()
+    newcolmap =  Graph%getColMap(); TEST_IERR()
+    newimporter = TpetraImport(newdomainmap, newcolmap ); TEST_IERR()
 
-    !call newdomainmap%release(); TEST_IERR()
-    !call newimporter%release(); TEST_IERR()
-    !call Obj%release(); TEST_IERR()
+    TEST_NOTHROW(call Graph%replaceDomainMapAndImporter(newdomainmap, newimporter))
 
-    write(*,*) 'TpetraCrsGraph_replaceDomainMapAndImporter: Test not yet implemented'
+    call newimporter%release(); TEST_IERR()
+    call newdomainmap%release(); TEST_IERR()
+    call newcolmap%release(); TEST_IERR()
+    call Graph%release(); TEST_IERR()
+    call Map%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_replaceDomainMapAndImporter!")
 
@@ -765,20 +1468,22 @@ contains
 
   ! -----------------------removeEmptyProcessesInPlace------------------------ !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_removeEmptyProcessesInPlace)
-    type(TpetraCrsGraph) :: Obj
-    type(TpetraMap) :: newmap
+    type(TpetraMap) :: Map
+    type(TpetraCrsGraph) :: Graph
+    integer(size_type), parameter :: izero=0, ione=1
+    integer(global_ordinal_type) :: num_global
+
     OUT0("Starting TpetraCrsGraph_removeEmptyProcessesInPlace!")
 
-    success = .false.
+    ! create Map and Graph
+    num_global = 4*comm%getSize()
+    Map = TpetraMap(num_global, comm); TEST_IERR()
+    Graph = TpetraCrsGraph(Map, Map, izero, TpetraStaticProfile)
 
-    !newmap = TpetraMap(); TEST_IERR()
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !call Obj%removeEmptyProcessesInPlace(newmap); TEST_IERR()
+    TEST_NOTHROW(call Graph%removeEmptyProcessesInPlace(Map))
 
-    !call newmap%release(); TEST_IERR()
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsGraph_removeEmptyProcessesInPlace: Test not yet implemented'
+    call Graph%release(); TEST_IERR()
+    call Map%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_removeEmptyProcessesInPlace!")
 
@@ -786,17 +1491,16 @@ contains
 
   ! ---------------------------haveGlobalConstants---------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_haveGlobalConstants)
-    type(TpetraCrsGraph) :: Obj
+    type(TpetraCrsGraph) :: Graph
+
     OUT0("Starting TpetraCrsGraph_haveGlobalConstants!")
 
-    success = .false.
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
+    call Graph%fillComplete()     ! Needed for global constants
 
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !fresult = Obj%haveGlobalConstants(); TEST_IERR()
+    TEST_ASSERT(Graph%haveGlobalConstants())
 
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsGraph_haveGlobalConstants: Test not yet implemented'
+    call Graph%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_haveGlobalConstants!")
 
@@ -804,92 +1508,18 @@ contains
 
   ! --------------------------computeGlobalConstants-------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsGraph_computeGlobalConstants)
-    type(TpetraCrsGraph) :: Obj
+    type(TpetraCrsGraph) :: Graph
+
     OUT0("Starting TpetraCrsGraph_computeGlobalConstants!")
 
-    success = .false.
+    call Tpetra_CrsGraph_CreateTestGraph_B(comm, Graph)
 
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !call Obj%computeGlobalConstants(); TEST_IERR()
+    TEST_NOTHROW(call Graph%computeGlobalConstants(.true.))
 
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsGraph_computeGlobalConstants: Test not yet implemented'
+    call Graph%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsGraph_computeGlobalConstants!")
 
   END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_computeGlobalConstants)
 
-  ! ----------------------------insertLocalIndices---------------------------- !
-  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_insertLocalIndices)
-    type(TpetraCrsGraph) :: Obj
-    integer(C_INT) :: localrow
-    integer(C_INT), allocatable :: indices(:)
-    OUT0("Starting TpetraCrsGraph_insertLocalIndices!")
-
-    success = .false.
-
-    localrow = 0
-    !allocate(indices(:)(0))
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !call Obj%insertLocalIndices(localrow, indices(:)); TEST_IERR()
-
-    !deallocate(indices(:))
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsGraph_insertLocalIndices: Test not yet implemented'
-
-    OUT0("Finished TpetraCrsGraph_insertLocalIndices!")
-
-  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_insertLocalIndices)
-
-  ! -----------------------------getGlobalRowCopy----------------------------- !
-  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getGlobalRowCopy)
-    type(TpetraCrsGraph) :: Obj
-    integer(C_LONG_LONG) :: globalrow
-    integer(C_LONG_LONG), allocatable :: indices(:)
-    integer(C_SIZE_T) :: numindices
-    OUT0("Starting TpetraCrsGraph_getGlobalRowCopy!")
-
-    success = .false.
-
-    globalrow = 0
-    !allocate(indices(:)(0))
-    numindices = 0
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !call Obj%getGlobalRowCopy(globalrow, indices(:), numindices); TEST_IERR()
-
-    !deallocate(indices(:))
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsGraph_getGlobalRowCopy: Test not yet implemented'
-
-    OUT0("Finished TpetraCrsGraph_getGlobalRowCopy!")
-
-  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getGlobalRowCopy)
-
-  ! ------------------------------getGlobalRowView------------------------------- !
-  FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getGlobalRowView)
-    type(TpetraCrsGraph) :: Obj
-    integer(C_LONG_LONG) :: gblrow
-    integer(C_LONG_LONG), allocatable :: lclcolinds(:)
-    OUT0("Starting TpetraCrsGraph_getGlobalRowView!")
-
-    success = .false.
-
-    gblrow = 0
-    !allocate(lclcolinds(:)(0))
-    !Obj = TpetraCrsGraph(); TEST_IERR()
-    !call Obj%getGlobalRowView(gblrow, lclcolinds(:)); TEST_IERR()
-
-    !deallocate(lclcolinds(:))
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsGraph_getGlobalRowView: Test not yet implemented'
-
-    OUT0("Finished TpetraCrsGraph_getGlobalRowView!")
-
-  END_FORTRILINOS_UNIT_TEST(TpetraCrsGraph_getGlobalRowView)
-#endif
-
-end program test_TpetraCrsGraph
+end program test_tpetraCrsGraph

--- a/src/tpetra/test/test_tpetra_crsgraph_helper.F90
+++ b/src/tpetra/test/test_tpetra_crsgraph_helper.F90
@@ -1,0 +1,185 @@
+! Copyright 2017-2018, UT-Battelle, LLC
+!
+! SPDX-License-Identifier: BSD-3-Clause
+! License-Filename: LICENSE
+!
+! Routines for creating matrices for testing
+! Functions would be more elegant, but rcp errors occurred
+!
+#include "ForTrilinosTpetra_config.hpp"
+module test_Tpetra_crsgraph_helper
+  use iso_fortran_env
+  use, intrinsic :: iso_c_binding
+  use forteuchos
+  use forTpetra
+
+  implicit none
+
+contains
+  ! helper functions to define simple tests
+  function test_graph_num_local() result (n)
+    integer :: n
+    n = 10
+  end function test_graph_num_local
+
+  function test_graph_num_row() result (n)
+    integer :: n
+    n = 4
+  end function test_graph_num_row
+
+  function test_graph_max_entries_per_row() result (n)
+    integer(size_type) :: n
+    n = 3
+  end function test_graph_max_entries_per_row
+
+  ! ----------------------- Create Basic Graph ------------------------------- !
+  !   do not call fillComplete
+  subroutine Tpetra_CrsGraph_CreateBasic(comm,Graph)
+    type(TeuchosComm), intent(in) :: comm
+    type(TpetraCrsGraph), intent(out) :: Graph
+    type(TpetraMap) :: map
+
+    ! create a Map
+    Map = TpetraMap(TPETRA_GLOBAL_INVALID, test_graph_num_local(), comm)
+    Graph = TpetraCrsGraph(Map, Map, int(test_graph_num_local(),size_type), TpetraStaticProfile)
+
+    call map%release()
+    return
+  end subroutine Tpetra_CrsGraph_CreateBasic
+  ! ----------------------- Create Test Graph ------------------------------- !
+  subroutine Tpetra_CrsGraph_CreateTestGraph_B(comm,Graph)
+    type(TeuchosComm), intent(in) :: comm
+    type(TpetraCrsGraph), intent(out) :: Graph
+    type(TpetraMap) :: rmap, cmap
+    integer(size_type) :: num_ent_per_row
+    integer(global_ordinal_type) :: myrowind
+    integer(global_ordinal_type), allocatable :: indices(:)
+    integer :: lclrow
+
+    ! create maps
+    rmap = TpetraMap(TPETRA_GLOBAL_INVALID, test_graph_num_local(), comm)
+    cmap = TpetraMap(TPETRA_GLOBAL_INVALID, test_graph_num_local(), comm)
+
+    ! must allocate enough for all submitted indices.
+    num_ent_per_row = 2
+    Graph = TpetraCrsGraph(rmap, cmap, num_ent_per_row, TpetraStaticProfile)
+
+    lclrow = 1
+    myrowind = rmap%getGlobalElement(lclrow);
+
+    ! insertGlobalIndices doesn't do column Map filtering, so we have to test
+    ! whether each of the column indices to insert is invalid.
+    if (cmap%isNodeGlobalElement(myrowind)) then
+      if (cmap%isNodeGlobalElement(myrowind+1)) then
+        allocate(indices(2))
+        indices = [myrowind, myrowind+1]
+        call Graph%insertGlobalIndices(myrowind, indices)
+        deallocate(indices)
+      else
+        allocate(indices(1))
+        indices(1) = myrowind
+        call Graph%insertGlobalIndices(myrowind, indices)
+        deallocate(indices)
+      end if
+    end if
+
+    call rmap%release();
+    call cmap%release();
+
+    return
+  end subroutine Tpetra_CrsGraph_CreateTestGraph_B
+  ! ------------------------------- Create Test Graph2 ------------------------- !
+  !   do not call fillComplete
+  !  This is the graph of the following matrix that is created in
+  !     test_tpetra_crsmatrix_helper
+  !  [2 1           ]
+  !  [1 1 1         ]
+  !  [  1 1 1       ]
+  !  [   . . .      ]
+  !  [     . . .    ]
+  !  [       . . .  ]
+  !  [         1 1 1]
+  !  [           1 2]
+  ! this matrix has an eigenvalue lambda=3, with eigenvector v = [1 ... 1]
+  subroutine Tpetra_CrsGraph_GetTestGraphRow_A(comm, irow, gblrow, cols, nnz)
+    type(TeuchosComm), intent(in) :: comm
+    integer, intent(in) :: irow
+    integer(global_ordinal_type), intent(out), allocatable :: cols(:)
+    integer, intent(out) :: nnz
+    integer(global_ordinal_type), intent(out) :: gblrow
+    integer :: num_images, my_image_id
+    num_images = comm%getSize()
+    my_image_id = comm%getRank()
+
+    if (num_images < 2) then
+      gblrow = irow
+    else
+      gblrow = my_image_id*test_graph_num_row() + irow
+    endif
+    if (gblrow == 1) then
+      nnz = 2
+      allocate(cols(nnz))
+      cols = [gblrow, gblrow+1]
+    else if (gblrow == num_images*test_graph_num_row()) then
+      nnz = 2
+      allocate(cols(nnz))
+      cols = [gblrow-1, gblrow]
+    else
+      nnz = 3
+      allocate(cols(nnz))
+      cols = [gblrow-1, gblrow, gblrow+1]
+    end if
+
+  end subroutine Tpetra_CrsGraph_GetTestGraphRow_A
+
+  subroutine Tpetra_CrsGraph_CreateTestGraph_A(comm,Graph)
+
+    type(TeuchosComm), intent(in) :: comm
+    type(TpetraCrsGraph), intent(out) :: Graph
+    type(TpetraMap) :: rmap
+    integer :: irow, nnz
+    integer(global_ordinal_type), allocatable :: cols(:)
+    integer(global_ordinal_type) :: gblrow
+
+    rmap = TpetraMap(Tpetra_GLOBAL_INVALID, test_graph_num_row(), comm)
+    Graph = TpetraCrsGraph(rmap, test_graph_max_entries_per_row(), TpetraStaticProfile)
+
+    do irow=1,test_graph_num_row()
+      call Tpetra_CrsGraph_GetTestGraphRow_A(comm, irow, gblrow, cols, nnz)
+      call Graph%insertGlobalIndices(gblrow, cols)
+      deallocate(cols)
+    enddo
+
+    call rmap%release();
+
+    return
+  end subroutine Tpetra_CrsGraph_CreateTestGraph_A
+  ! ------------------------------- Get Test Graph2 Results ------------------ !
+  ! Hard-code the results graph for getAllValues test from the TestGraph2
+  ! routine above
+
+! MDM - commented this out because we don't currently use it
+! TO add back in when it's actually tested or delete this if not needed.
+
+!  subroutine Tpetra_CrsGraph_getTestGraphResults(comm, row_ptrs, cols)
+!    type(TeuchosComm), intent(in) :: comm
+!    integer(size_type), dimension(:), intent(out) :: row_ptrs
+!    integer(int_type), dimension(:), intent(out) :: cols
+!    integer :: nnz, irow, idx, i
+!    integer(global_ordinal_type), allocatable :: cols_row(:)
+!    integer(global_ordinal_type) :: gblrow
+!
+!    row_ptrs(1)=1
+!    do irow=1,test_graph_num_row()
+!      idx=row_ptrs(irow)
+!      call Tpetra_CrsGraph_GetTestGraphRow(comm, irow, gblrow, cols_row, nnz)
+!      do i=1,nnz
+!        cols(idx+i-1) = cols_row(i)
+!      enddo
+!      row_ptrs(irow+1)=row_ptrs(irow)+nnz
+!      deallocate(cols_row)
+!    enddo
+!
+!    return
+!  end subroutine Tpetra_CrsGraph_getTestGraphResults
+end module test_tpetra_crsgraph_helper

--- a/src/tpetra/test/test_tpetra_crsmatrix.F90
+++ b/src/tpetra/test/test_tpetra_crsmatrix.F90
@@ -9,10 +9,12 @@ program test_TpetraCrsMatrix
   use, intrinsic :: iso_c_binding
   use forteuchos
   use fortpetra
+  use test_tpetra_crsmatrix_helper
 
   implicit none
   type(TeuchosComm) :: comm
   character(len=256), parameter :: FILENAME="test_tpetra_crsmatrix.F90"
+  integer, parameter :: dp = kind(0.d0)
 
   SETUP_TEST()
 
@@ -22,27 +24,62 @@ program test_TpetraCrsMatrix
   comm = TeuchosComm(); FORTRILINOS_CHECK_IERR()
 #endif
 
+  !Fat tests
   ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_Basic1)
   ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_AlphaBetaMultiply)
   ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_ActiveFillGlobal)
   ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_EigTest)
 
-!  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_ActiveFillLocal)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_replaceColMap)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_replaceDomainMapAndImporter)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_removeEmptyProcessesInPlace)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getCrsGraph)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_isStorageOptimized)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_isStaticGraph)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_supportsRowViews)
+  !Unit tests consistent with scripts/autogen_tests.py
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getComm)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getRowMap)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getColMap)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getDomainMap)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getRangeMap)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getCrsGraph)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getGlobalNumRows)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getGlobalNumCols)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getNodeNumRows)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getNodeNumCols)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getGlobalNumEntries)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getNodeNumEntries)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getNumEntriesInGlobalRow)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getNumEntriesInLocalRow)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getGlobalMaxNumRowEntries)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getNodeMaxNumRowEntries)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getGlobalRowCopy)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getLocalRowCopy)
   ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getGlobalRowView)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getLocalRowViewRaw)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_gaussSeidel)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_reorderedGaussSeidel)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_gaussSeidelCopy)
-!  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_reorderedGaussSeidelCopy)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getProfileType)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getFrobeniusNorm)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_getAllValues)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_setAllValues)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_insertGlobalValues)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_insertLocalValues)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_replaceGlobalValues)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_setAllToScalar)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_scale)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_globalAssemble)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_replaceColMap)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_replaceDomainMapAndImporter)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_removeEmptyProcessesInPlace)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_hasColMap)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_isLocallyIndexed)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_isGloballyIndexed)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_isFillComplete)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_isFillActive)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_isStorageOptimized)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_isStaticGraph)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_supportsRowViews)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_hasTransposeApply)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_description)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_computeGlobalConstants)
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_haveGlobalConstants)
 
-  call comm%release()
+  ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_gaussSeidel)
+  !TODO-implement ADD_SUBTEST_AND_RUN(TpetraCrsMatrix_gaussSeidelCopy)
+
+  call comm%release();  TEST_IERR()
 
   TEARDOWN_TEST()
 
@@ -57,7 +94,6 @@ contains
     character(kind=C_CHAR, len=:), allocatable :: description
     integer :: num_images, my_image_id
     integer(size_type), parameter :: num_vecs=5
-    integer, parameter :: num_local=10
     integer :: irow
     integer(global_ordinal_type) :: base, gblrow, cols(1)
     real(mag_type) :: vals(1)=[1.], norms(num_vecs), zeros(num_vecs), fnorm
@@ -70,15 +106,15 @@ contains
     my_image_id = comm%getRank()
 
     ! create a Map
-    map = TpetraMap(TPETRA_GLOBAL_INVALID, num_local, comm); TEST_IERR()
+    map = TpetraMap(TPETRA_GLOBAL_INVALID, test_matrix_num_local(), comm); TEST_IERR()
     mvrand = TpetraMultiVector(Map, num_vecs, .false.); TEST_IERR()
     mvres = TpetraMultiVector(Map, num_vecs, .false.); TEST_IERR()
     call mvrand%randomize(); TEST_IERR()
 
     ! create the identity matrix
-    base = num_local * my_image_id;
+    base = test_matrix_num_local() * my_image_id;
     Mat = TpetraCrsMatrix(Map, 1_size_type, TpetraStaticProfile)
-    do irow = 1, num_local
+    do irow = 1, test_matrix_num_local()
       gblrow = base + int(irow, kind=global_ordinal_type)
       cols(1) = gblrow
       vals(1) = 1.d0
@@ -92,17 +128,17 @@ contains
     row_map = Mat%getRowMap()
 
     ! test the properties
-    TEST_ASSERT(Mat%getGlobalNumEntries()==num_images*num_local)
-    TEST_ASSERT(Mat%getNodeNumEntries()==num_local)
-    TEST_ASSERT(Mat%getGlobalNumRows()==num_images*num_local)
-    TEST_ASSERT(Mat%getGlobalNumCols()==num_images*num_local)
-    TEST_ASSERT(Mat%getNodeNumRows()==num_local)
-    TEST_ASSERT(Mat%getNodeNumCols()==num_local)
+    TEST_ASSERT(Mat%getGlobalNumEntries()==num_images*test_matrix_num_local())
+    TEST_ASSERT(Mat%getNodeNumEntries()==test_matrix_num_local())
+    TEST_ASSERT(Mat%getGlobalNumRows()==num_images*test_matrix_num_local())
+    TEST_ASSERT(Mat%getGlobalNumCols()==num_images*test_matrix_num_local())
+    TEST_ASSERT(Mat%getNodeNumRows()==test_matrix_num_local())
+    TEST_ASSERT(Mat%getNodeNumCols()==test_matrix_num_local())
     TEST_ASSERT(Mat%getGlobalMaxNumRowEntries()==1)
     TEST_ASSERT(Mat%getNodeMaxNumRowEntries()==1)
     TEST_ASSERT(Mat%isFillComplete())
     TEST_ASSERT((.not. Mat%isFillActive()))
-    fnorm = sqrt(real(num_images*num_local, kind=scalar_type))
+    fnorm = sqrt(real(num_images*test_matrix_num_local(), kind=scalar_type))
     TEST_ASSERT(Mat%getFrobeniusNorm()==fnorm)
     tmp_map = Mat%getColMap(); TEST_IERR()
     TEST_ASSERT(row_map%isSameAs(tmp_map))
@@ -115,8 +151,6 @@ contains
     call tmp_map%release(); TEST_IERR()
     TEST_ASSERT(Mat%hasColMap())
     TEST_ASSERT(Mat%haveGlobalConstants())
-    !TEST_ASSERT((.not. Mat%isLowerTriangular())) ! FIXME: This throws an error from Tpetra
-    !TEST_ASSERT((.not. Mat%isUpperTriangular())) ! FIXME: This tthrows an error from Tpetra
     TEST_ASSERT(Mat%isLocallyIndexed())
     TEST_ASSERT(Mat%hasTransposeApply())
     TEST_ASSERT((.not. Mat%isGloballyIndexed()))
@@ -128,7 +162,7 @@ contains
     ! get the description, just to see if it does not throw
     description = Mat%description(); TEST_IERR()
 
-    do irow = 1, num_local
+    do irow = 1, test_matrix_num_local()
       gblrow = row_map%getGlobalElement(irow)
       TEST_ASSERT(gblrow == (base + int(irow, kind=global_ordinal_type)))
       TEST_ASSERT(Mat%getNumEntriesInGlobalRow(gblrow)==1)
@@ -179,92 +213,58 @@ contains
 
   ! -------------------------- EigTest --------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_EigTest)
-    type(TpetraMap) :: Map, row_map
+    type(TpetraMap) :: row_map, tmp_map
     type(TpetraCrsMatrix) :: A
     type(TpetraMultiVector) :: ones, threes
-    integer :: num_images, my_image_id
+    integer :: num_images, my_image_id, nnz, nrow, nrm
     integer(size_type) :: numindices
-    integer :: nnz
     real(norm_type) :: norms(1)
     integer(global_ordinal_type) :: gblrow
-    integer(global_ordinal_type), allocatable :: cols(:), xcols(:)
+    integer(global_ordinal_type), allocatable :: xcols(:)
     real(scalar_type), allocatable :: vals(:), xvals(:)
 
     OUT0("Starting TpetraCrsMatrix_EigTest")
     num_images = comm%getSize()
     my_image_id = comm%getRank()
 
-    if (num_images < 2) return
-
-    ! create a Map
-    map = TpetraMap(TPETRA_GLOBAL_INVALID, 1, comm); TEST_IERR()
-
-    ! create a multivector ones(n,1)
-    ones = TpetraMultiVector(map, 1_size_type, .false.); TEST_IERR()
-    threes = TpetraMultiVector(map, 1_size_type, .false.); TEST_IERR()
-    call ones%putScalar(1.d0)
-
-    !  create the following matrix:
-    !  [2 1           ]
-    !  [1 1 1         ]
-    !  [  1 1 1       ]
-    !  [   . . .      ]
-    !  [     . . .    ]
-    !  [       . . .  ]
-    !  [         1 1 1]
-    !  [           1 2]
-    ! this matrix has an eigenvalue lambda=3, with eigenvector v = [1 ... 1]
-
-    A = TpetraCrsMatrix(map, 3_size_type, TpetraStaticProfile); TEST_IERR()
-    gblrow = my_image_id + 1
-    if (gblrow == 1) then
-      nnz = 2
-      allocate(cols(nnz)); allocate(vals(nnz));
-      cols(1:nnz) = [gblrow, gblrow+1]
-      vals(1:nnz) = [2.d0, 1.d0]
-      call A%insertGlobalValues(gblrow, cols, vals); TEST_IERR()
-    else if (gblrow == num_images) then
-      nnz = 2;
-      allocate(cols(nnz)); allocate(vals(nnz));
-      cols(1:nnz) = [gblrow-1, gblrow]
-      vals(1:nnz) = [1.d0, 2.d0]
-      call A%insertGlobalValues(gblrow, cols, vals); TEST_IERR()
-    else
-      nnz = 3;
-      allocate(cols(nnz)); allocate(vals(nnz));
-      vals = [1.d0, 1.d0, 1.d0]
-      cols = [gblrow-1, gblrow, gblrow+1]
-      call A%insertGlobalValues(gblrow, cols, vals); TEST_IERR()
-    end if
-
+    call TPetra_CrsMatrix_CreateTestMatrix_A(comm,A)
     call A%fillComplete(); TEST_IERR()
     row_map = A%getRowMap(); TEST_IERR()
 
-    ! test the properties
-    TEST_ASSERT(A%getGlobalNumEntries()==3*num_images-2)
-    TEST_ASSERT(A%getNodeNumEntries()==nnz)
-    TEST_ASSERT(A%getGlobalNumRows()==num_images)
-    TEST_ASSERT(A%getNodeNumRows()==1)
-    TEST_ASSERT(A%getNodeNumCols()==nnz)
-    if (num_images > 2) then
-      TEST_ASSERT(A%getGlobalMaxNumRowEntries()==3)
+    ! Must match TPetra_CrsMatrix_CreateTestMatrix
+    nnz=3
+    nrow=4
+    if (my_image_id==0 .or. my_image_id==num_images-1) then
+       nrm=1
     else
-      TEST_ASSERT(A%getGlobalMaxNumRowEntries()==2)
-    end if
+       nrm=0
+    endif
+    if (num_images==1) nrm=2
+
+    ! test the properties
+    TEST_ASSERT(A%getGlobalNumEntries()==nnz*nrow*num_images-2)
+    TEST_ASSERT(A%getNodeNumEntries()==nnz*nrow-nrm)
+    TEST_ASSERT(A%getGlobalNumRows()==num_images*nrow)
+    TEST_ASSERT(A%getNodeNumRows()==nrow)
+    TEST_ASSERT(A%getNodeNumCols()==nnz+(nrow-1)-nrm)
+    TEST_ASSERT(A%getGlobalMaxNumRowEntries()==nnz)
     TEST_ASSERT(A%getNodeMaxNumRowEntries()==nnz)
-    TEST_ASSERT((.not. row_map%isSameAs(A%getColMap())))
-    TEST_ASSERT(row_map%isSameAs(A%getDomainMap()))
-    TEST_ASSERT(row_map%isSameAs(A%getRangeMap()))
+    ! Use tmp_map so it can be released
+    tmp_map=A%getColMap()
+    if (num_images==1) then
+      TEST_ASSERT(row_map%isSameAs(tmp_map))        ! Same in serial
+    else
+      TEST_ASSERT(.not. row_map%isSameAs(tmp_map))  ! not same on all procs
+    endif
+    tmp_map=A%getDomainMap()
+    TEST_ASSERT(row_map%isSameAs(tmp_map))
+    tmp_map=A%getRangeMap()
+    TEST_ASSERT(row_map%isSameAs(tmp_map))
 
-    ! FIXME: getGlobalRowCopy: I expected cols and vals to be in ascending
-    ! FIXME: order, but they are not, so I have commented out the check
-    allocate(xcols(nnz)); allocate(xvals(nnz))
-    numindices = int(nnz, kind=size_type)
-    call A%getGlobalRowCopy(gblrow, xcols, xvals, numindices); TEST_IERR()
-    !TEST_ARRAY_EQUALITY(xcols, cols)
-    !TEST_FLOATING_ARRAY_EQUALITY(xvals, vals, epsilon(0.d0))
-    deallocate(xcols); deallocate(xvals)
-
+    ! create a multivector ones(n,1)
+    ones = TpetraMultiVector(row_map, 1_size_type, .false.); TEST_IERR()
+    threes = TpetraMultiVector(row_map, 1_size_type, .false.); TEST_IERR()
+    call ones%putScalar(1.d0)
     ! test the action
     call threes%randomize(); TEST_IERR()
     call A%apply(ones, threes); TEST_IERR()
@@ -274,12 +274,11 @@ contains
     call threes%norm1(norms)
     TEST_FLOATING_ARRAY_EQUALITY(norms, 0.d0, epsilon(0.d0))
 
-    call ones%release()
-    call threes%release()
-    call Map%release()
-    call A%release()
-    call row_map%release()
-    deallocate(cols); deallocate(vals)
+    call ones%release();  TEST_IERR()
+    call threes%release();  TEST_IERR()
+    call A%release();  TEST_IERR()
+    call row_map%release();  TEST_IERR()
+    call tmp_map%release();  TEST_IERR()
 
     OUT0("Finished TpetraCrsMatrix_EigTest!")
 
@@ -333,11 +332,11 @@ contains
     call Y%norm1(normy)
     TEST_FLOATING_ARRAY_EQUALITY(normy, normz, epsilon(0.d0))
 
-    call Z%release()
-    call Y%release()
-    call X%release()
-    call Mat%release()
-    call Map%release()
+    call Z%release();  TEST_IERR()
+    call Y%release();  TEST_IERR()
+    call X%release();  TEST_IERR()
+    call Mat%release();  TEST_IERR()
+    call Map%release();  TEST_IERR()
 
     OUT0("Finished TpetraCrsMatrix_AlphaBetaMultiply!")
   END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_AlphaBetaMultiply)
@@ -389,8 +388,8 @@ contains
     TEST_THROW(call Mat%globalAssemble())
     TEST_THROW(call Mat%fillComplete())
 
-    call params%release()
-    call Mat%release()
+    call params%release();  TEST_IERR()
+    call Mat%release();  TEST_IERR()
 
     Mat = TpetraCrsMatrix(map, map,10_size_type, TpetraStaticProfile); TEST_IERR()
     TEST_ASSERT(Mat%isFillActive())
@@ -398,9 +397,6 @@ contains
     lclrow = 1
     row = map%getGlobalElement(lclrow)
     cols(1) = row; vals(1) = 0.d0;
-    ! FIXME: If a mistake is made, and cols above is just set to 1:
-    ! cols(1) = 1
-    ! FIXME: then the call to fillComplete below hangs indefinitely
     call Mat%insertGlobalValues(row, cols, vals); TEST_IERR()
 
     params = ParameterList("ANONYMOUS"); TEST_IERR()
@@ -412,8 +408,6 @@ contains
     TEST_ASSERT(Mat%isFillActive())
     TEST_ASSERT((.not. Mat%isFillComplete()))
 
-    ! FIXME: The following should NOT set ierr/=0 but does
-    !TEST_NOTHROW(call Mat%insertGlobalValues(row, cols, vals))
     TEST_NOTHROW(numvalid = Mat%replaceGlobalValues(row, cols, vals))
     TEST_NOTHROW(numvalid = Mat%sumIntoGlobalValues(row, cols, vals))
     TEST_NOTHROW(call Mat%setAllToScalar(0.d0))
@@ -424,16 +418,15 @@ contains
     TEST_ASSERT((.not. Mat%isFillActive()))
     TEST_ASSERT(Mat%isFillComplete())
 
-    call params%release()
-    call Map%release()
-    call Mat%release()
+    call params%release();  TEST_IERR()
+    call Map%release();  TEST_IERR()
+    call Mat%release();  TEST_IERR()
 
     OUT0("Finished TpetraCrsMatrix_ActiveFillGlobal!")
 
   END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_ActiveFillGlobal)
 
 #if 0
-
   ! ----------------------------- ActiveFill --------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_ActiveFillLocal)
     type(TpetraMap) :: Map
@@ -477,8 +470,8 @@ contains
     TEST_THROW(call Mat%globalAssemble())
     TEST_THROW(call Mat%fillComplete())
 
-    call params%release()
-    call Mat%release()
+    call params%release();  TEST_IERR()
+    call Mat%release();  TEST_IERR()
 
     Mat = TpetraCrsMatrix(map, map, 1, TpetraStaticProfile); TEST_IERR()
     TEST_ASSERT(Mat%isFillActive())
@@ -500,53 +493,1065 @@ contains
     TEST_NOTHROW(call Mat%sumIntoLocalValues(row, cols, vals))
 
     ! FIXME: The following should NOT set ierr/=0 but does
-    TEST_NOTHROW(call Mat%setAllToScalar(0.d0))
-    TEST_NOTHROW(call Mat%scale(0.d0))
+    TEST_NOTHROW(call Mat%setAllToScalar(zero))
+    TEST_NOTHROW(call Mat%scale(zero))
     TEST_NOTHROW(call Mat%globalAssemble())
 
     TEST_NOTHROW(call Mat%fillComplete())
     TEST_ASSERT((.not. Mat%isFillActive()))
     TEST_ASSERT(Mat%isFillComplete())
 
-    call params%release()
-    call Map%release()
-    call Mat%release()
+    call params%release();  TEST_IERR()
+    call Map%release();  TEST_IERR()
+    call Mat%release();  TEST_IERR()
 
     OUT0("Finished TpetraCrsMatrix_ActiveFillLocal!")
 
   END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_ActiveFillLocal)
 
+#endif
+
+  ! ---------------------------------getComm---------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getComm)
+    type(TpetraCrsMatrix) :: Mat
+    type(TeuchosComm) :: tcomm
+
+    OUT0("Starting TpetraCrsMatrix_getComm!")
+
+    ! get identity matrix
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    tcomm = Mat%getComm()
+
+    TEST_ASSERT(tcomm%getRank() == comm%getRank())
+    TEST_ASSERT(tcomm%getSize() == comm%getSize())
+
+    call tcomm%release(); TEST_IERR()
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getComm!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getComm)
+
+  ! --------------------------------getRowMap--------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getRowMap)
+    type(TpetraMap) :: Map, tmpmap
+    type(TpetraCrsMatrix) :: Mat
+    integer :: lnum_local=2
+
+    OUT0("Starting TpetraCrsMatrix_getRowMap!")
+
+    ! create a Map
+    Map = TpetraMap(TPETRA_GLOBAL_INVALID, lnum_local, comm); TEST_IERR()
+    Mat = TpetraCrsMatrix(Map, 1_size_type, TpetraStaticProfile)
+
+    tmpmap = Mat%getRowMap()
+    TEST_EQUALITY(tmpmap%getNodeNumElements(), Map%getNodeNumElements())
+    TEST_ASSERT(tmpmap%isSameAs(Map))
+
+    call tmpmap%release(); TEST_IERR()
+    call Map%release(); TEST_IERR()
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getRowMap!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getRowMap)
+
+  ! --------------------------------getColMap--------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getColMap)
+    type(TpetraMap) :: Map, tmpmap
+    type(TpetraCrsMatrix) :: Mat
+    integer :: lnum_local=2
+
+    OUT0("Starting TpetraCrsMatrix_getColMap!")
+
+    ! create a Map
+    Map = TpetraMap(TPETRA_GLOBAL_INVALID, lnum_local, comm); TEST_IERR()
+    Mat = TpetraCrsMatrix(Map, Map, 1_size_type, TpetraStaticProfile)
+    TEST_NOTHROW(call Mat%fillComplete())
+
+    tmpmap = Mat%getColMap()
+    TEST_EQUALITY(tmpmap%getNodeNumElements(), Map%getNodeNumElements())
+
+    call tmpmap%release(); TEST_IERR()
+    call Map%release(); TEST_IERR()
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getColMap!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getColMap)
+
+  ! -------------------------------getDomainMap------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getDomainMap)
+    type(TpetraMap) :: Map, tmpmap
+    type(TpetraCrsMatrix) :: Mat
+    integer :: lnum_local=2
+
+    OUT0("Starting TpetraCrsMatrix_getDomainMap!")
+
+    ! create a Map
+    Map = TpetraMap(TPETRA_GLOBAL_INVALID, lnum_local, comm); TEST_IERR()
+    Mat = TpetraCrsMatrix(Map, Map, 1_size_type, TpetraStaticProfile)
+    TEST_NOTHROW(call Mat%fillComplete())
+
+    tmpmap = Mat%getDomainMap(); TEST_IERR()
+    TEST_ASSERT(Map%isSameAs(tmpmap))
+
+    call tmpmap%release(); TEST_IERR()
+    call Map%release(); TEST_IERR()
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getDomainMap!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getDomainMap)
+
+  ! -------------------------------getRangeMap-------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getRangeMap)
+    type(TpetraMap) :: Map, tmpmap
+    type(TpetraCrsMatrix) :: Mat
+    integer :: lnum_local=2
+
+    OUT0("Starting TpetraCrsMatrix_getRangeMap!")
+
+    ! create a Map
+    Map = TpetraMap(TPETRA_GLOBAL_INVALID, lnum_local, comm); TEST_IERR()
+    Mat = TpetraCrsMatrix(Map, Map, 1_size_type, TpetraStaticProfile)
+    TEST_NOTHROW(call Mat%fillComplete())
+
+    tmpmap = Mat%getRangeMap(); TEST_IERR()
+    TEST_ASSERT(Map%isSameAs(tmpmap))
+
+    call tmpmap%release(); TEST_IERR()
+    call Map%release(); TEST_IERR()
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getRangeMap!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getRangeMap)
+
   ! -------------------------------getCrsGraph-------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getCrsGraph)
-    type(TpetraCrsMatrix) :: Obj
+    type(TpetraCrsMatrix) :: mat
+    type(TpetraCrsGraph) :: graph
+
     OUT0("Starting TpetraCrsMatrix_getCrsGraph")
 
-    success = .false.
+    ! get identity matrix
+    call TPetra_CrsMatrix_CreateIdentity(comm, mat)
+    call mat%fillComplete()
 
-    !Obj = TpetraCrsMatrix(); TEST_IERR()
-    !fresult = Obj%getCrsGraph(); TEST_IERR()
+    TEST_NOTHROW(graph = Mat%getCrsGraph())
 
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsMatrix_getCrsGraph: Test not yet implemented'
+    call graph%release(); TEST_IERR()
+    call mat%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsMatrix_getCrsGraph")
 
   END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getCrsGraph)
 
+  ! -----------------------------getGlobalNumRows----------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getGlobalNumRows)
+    type(TpetraMap) :: Map
+    type(TpetraCrsMatrix) :: Mat
+    integer(size_type) :: num_ent_per_row, ires
+    integer :: lnum_local=2, commsize
+
+    OUT0("Starting TpetraCrsMatrix_getGlobalNumRows!")
+
+    ! create a Map
+    Map = TpetraMap(TPETRA_GLOBAL_INVALID, lnum_local, comm); TEST_IERR()
+    num_ent_per_row = 2
+    Mat = TpetraCrsMatrix(Map, Map, num_ent_per_row, TpetraStaticProfile)
+    call mat%fillComplete()
+
+    commsize = comm%getSize()
+    ires = Mat%getGlobalNumRows()
+    TEST_EQUALITY(ires, int(2*commsize,size_type))
+
+    call Map%release(); TEST_IERR()
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getGlobalNumRows!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getGlobalNumRows)
+
+  ! -----------------------------getGlobalNumCols----------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getGlobalNumCols)
+    type(TpetraMap) :: Map
+    type(TpetraCrsMatrix) :: Mat
+    integer(size_type) :: ires
+    integer :: commsize
+
+    OUT0("Starting TpetraCrsMatrix_getGlobalNumCols!")
+
+    commsize = comm%getSize()
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
+
+    ires = Mat%getGlobalNumCols()
+    TEST_EQUALITY(ires, int(test_matrix_num_local()*commsize,size_type))
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getGlobalNumCols!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getGlobalNumCols)
+
+  ! ------------------------------getNodeNumRows------------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getNodeNumRows)
+    type(TpetraCrsMatrix) :: Mat
+    integer(size_type) :: ires
+
+    OUT0("Starting TpetraCrsMatrix_getNodeNumRows!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
+
+    ires = Mat%getNodeNumRows()
+    TEST_EQUALITY(ires, int(test_matrix_num_local(),size_type))
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getNodeNumRows!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getNodeNumRows)
+
+  ! ------------------------------getNodeNumCols------------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getNodeNumCols)
+    type(TpetraCrsMatrix) :: Mat
+    integer(size_type) :: ires
+    integer :: commsize
+
+    OUT0("Starting TpetraCrsMatrix_getNodeNumCols!")
+
+    commsize = comm%getSize()
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
+
+    ires = Mat%getNodeNumCols()
+    TEST_EQUALITY(ires, int(test_matrix_num_local(),size_type))
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getNodeNumCols!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getNodeNumCols)
+
+  ! ---------------------------getGlobalNumEntries---------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getGlobalNumEntries)
+    type(TpetraCrsMatrix) :: Mat
+    integer(size_type) :: ires
+    integer :: commsize
+
+    OUT0("Starting TpetraCrsMatrix_getGlobalNumEntries!")
+
+    commsize = comm%getSize()
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
+
+    ires = Mat%getGlobalNumEntries()
+    TEST_EQUALITY(ires, int(commsize*test_matrix_num_local(),size_type))
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getGlobalNumEntries!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getGlobalNumEntries)
+
+  ! ----------------------------getNodeNumEntries----------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getNodeNumEntries)
+    type(TpetraCrsMatrix) :: Mat
+    integer(size_type) :: ires
+
+    OUT0("Starting TpetraCrsMatrix_getNodeNumEntries!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
+
+    ires = Mat%getNodeNumEntries()
+    TEST_EQUALITY(ires, int(test_matrix_num_local(),size_type))
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getNodeNumEntries!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getNodeNumEntries)
+
+  ! -------------------------getNumEntriesInGlobalRow------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getNumEntriesInGlobalRow)
+    type(TpetraCrsMatrix) :: Mat
+    integer(size_type) :: ires
+    integer :: commsize, my_rank
+    integer(global_ordinal_type) :: base
+
+    OUT0("Starting TpetraCrsMatrix_getNumEntriesInGlobalRow!")
+
+    commsize = comm%getSize()
+    my_rank = comm%getRank()
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    base = test_matrix_num_local() * my_rank
+    call Mat%fillComplete()
+
+    ires = Mat%getNumEntriesInGlobalRow(int(base+1,global_ordinal_type))
+    TEST_EQUALITY(ires, int(1,size_type))
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getNumEntriesInGlobalRow!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getNumEntriesInGlobalRow)
+
+  ! -------------------------getNumEntriesInLocalRow-------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getNumEntriesInLocalRow)
+    type(TpetraCrsMatrix) :: Mat
+    integer(size_type) :: ires
+
+    OUT0("Starting TpetraCrsMatrix_getNumEntriesInLocalRow!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
+
+    ires = Mat%getNumEntriesInLocalRow(1)
+    TEST_EQUALITY(ires, int(1,size_type))
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getNumEntriesInLocalRow!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getNumEntriesInLocalRow)
+
+  ! ------------------------getGlobalMaxNumRowEntries------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getGlobalMaxNumRowEntries)
+    type(TpetraCrsMatrix) :: Mat
+    integer(size_type) :: ires
+
+    OUT0("Starting TpetraCrsMatrix_getGlobalMaxNumRowEntries!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
+
+    ires = Mat%getGlobalMaxNumRowEntries()
+    TEST_EQUALITY(ires, int(1,size_type))
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getGlobalMaxNumRowEntries!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getGlobalMaxNumRowEntries)
+
+  ! -------------------------getNodeMaxNumRowEntries-------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getNodeMaxNumRowEntries)
+    type(TpetraCrsMatrix) :: Mat
+    integer(size_type) :: ires
+
+    OUT0("Starting TpetraCrsMatrix_getNodeMaxNumRowEntries!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
+
+    ires = Mat%getNodeMaxNumRowEntries()
+    TEST_EQUALITY(ires, int(1,size_type))
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getNodeMaxNumRowEntries!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getNodeMaxNumRowEntries)
+
+  ! -----------------------------getGlobalRowCopy----------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getGlobalRowCopy)
+    type(TpetraMap) :: rowMap
+    integer :: lclNumRows, lclRow
+    integer :: numProcs
+    integer(global_ordinal_type) gblNumRows, gblNumCols, gblRow
+    integer(global_ordinal_type), allocatable :: gblColInds(:)
+    real(mag_type), allocatable :: vals(:)
+    type(TpetraCrsMatrix) :: Mat
+    integer(size_type), parameter :: ithree=3
+    integer(global_ordinal_type) :: numEnt=0
+
+    OUT0("Starting TpetraCrsMatrix_getGlobalRowCopy!")
+    call Tpetra_CrsMatrix_CreateLabelledMat(comm, Mat)
+    ! Do not call this as the re-ordering done will break tests
+    !call Mat%fillComplete()
+    rowmap = Mat%getRowMap()
+
+    numProcs = comm%getSize()
+    gblNumRows = test_matrix_num_local() * numProcs
+    gblNumCols = gblNumRows
+
+    ! Make the arrays bigger than necessary for simplicity
+    allocate(gblColInds(5),vals(5))
+
+    do lclRow = 1, test_matrix_num_local()
+      gblRow = rowMap%getGlobalElement(lclRow)
+      TEST_NOTHROW(call Mat%getGlobalRowCopy(gblRow, gblColInds, vals, numEnt))
+
+      TEST_EQUALITY(int(numEnt), 2)
+
+      TEST_EQUALITY(gblColInds(1), 1 + modulo(gblRow + 0, gblNumCols))
+      TEST_EQUALITY(gblColInds(2), 1 + modulo(gblRow + 1, gblNumCols))
+
+      TEST_EQUALITY(int(vals(1)), int(gblColInds(1)))
+      TEST_EQUALITY(int(vals(2)), int(gblColInds(2)))
+    end do
+
+    call Mat%release(); TEST_IERR()
+    call rowMap%release(); TEST_IERR()
+    deallocate(gblColInds,vals)
+
+    OUT0("Finished TpetraCrsMatrix_getGlobalRowCopy!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getGlobalRowCopy)
+
+  ! -----------------------------getLocalRowCopy------------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getLocalRowCopy)
+    type(TpetraMap) :: rowMap, colMap
+    integer(int_type) :: lclNumRows, lclNumCols, lclRow
+    integer(global_ordinal_type) gblNumRows
+    integer(int_type) :: numProcs
+    integer(int_type), dimension(:), allocatable :: lclColInds
+    real(mag_type), allocatable :: vals(:)
+    integer(int_type), dimension(:), allocatable :: curLclColInds
+    real(mag_type), allocatable :: curVals(:)
+    type(TpetraCrsMatrix) :: Mat
+    integer(size_type), parameter :: ithree=3
+    integer(size_type) :: numEnt=0
+
+    OUT0("Starting TpetraCrsMatrix_getLocalRowCopy!")
+
+    ! Note that this test is currently identical to TpetraCrsMatrix_insertLocalValues
+    ! because they both test getLocalRowCopy and insertLocalValues
+    numProcs = comm%getSize()
+    lclNumRows = 10
+    gblNumRows = lclNumRows * numProcs
+    rowMap = TpetraMap(gblNumRows, lclNumRows, comm)
+
+    ! We need a locally indexed matrix to test getLocalRowCopy, so we
+    ! need a column Map.  It can be the same as the row Map in this
+    ! case, since we're not testing global effects.
+    colMap = rowMap
+    lclNumCols = lclNumRows
+
+    ! Leave room for three locally owned entries per row.
+    ! We will only fill in two entries per row.
+    Mat = TpetraCrsMatrix(rowMap, colMap, ithree, TpetraStaticProfile)
+
+    allocate(lclColInds(2))
+    allocate(vals(2))
+
+    do lclRow = 1, lclNumRows
+      lclColInds(1) = 1 + modulo(lclRow + 0, lclNumCols)
+      lclColInds(2) = 1 + modulo(lclRow + 1, lclNumCols)
+
+      vals(1) = lclColInds(1)
+      vals(2) = lclColInds(2)
+
+      TEST_NOTHROW(call Mat%insertLocalValues(lclRow, lclColInds, vals))
+    end do
+
+    TEST_ASSERT(.not. Mat%isFillComplete());
+
+    ! Make the arrays bigger than necessary, just to make sure that
+    ! the methods behave correctly.
+    allocate(curLclColInds(5))
+    allocate(curVals(5))
+
+    do lclRow = 1, lclNumRows
+      TEST_NOTHROW(call Mat%getLocalRowCopy(lclRow, curLclColInds, curVals, numEnt))
+      TEST_EQUALITY(int(numEnt), 2)
+
+      TEST_EQUALITY(curLclColInds(1), 1 + modulo(lclRow + 0, lclNumCols));
+      TEST_EQUALITY(curLclColInds(2), 1 + modulo(lclRow + 1, lclNumCols));
+
+      TEST_EQUALITY(int(curVals(1)), curLclColInds(1));
+      TEST_EQUALITY(int(curVals(2)), curLclColInds(2));
+    end do
+
+    call Mat%release(); TEST_IERR()
+    call rowMap%release(); TEST_IERR()
+    call colMap%release(); TEST_IERR()
+    deallocate(lclColInds)
+    deallocate(vals)
+    deallocate(curLclColInds)
+    deallocate(curVals)
+
+    OUT0("Finished TpetraCrsMatrix_getLocalRowCopy!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getLocalRowCopy)
+
+  ! -----------------------------getGlobalRowView----------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_GetGlobalRowView)
+    type(TpetraMap) :: rowMap
+    type(TpetraCrsMatrix) :: Mat
+    integer :: numrow, irow, nnz
+    integer(global_ordinal_type), dimension(:), pointer :: view_cols
+    real(scalar_type), dimension(:), pointer :: view_vals
+    integer(global_ordinal_type) :: gblrow
+    integer(global_ordinal_type), allocatable :: compare_cols(:)
+    real(scalar_type), allocatable :: compare_vals(:)
+
+    OUT0("Starting TpetraCrsMatrix_GetGlobalRowView")
+
+    call TPetra_CrsMatrix_CreateTestMatrix_A(comm,Mat)
+
+    numrow = Mat%getNodeNumRows()
+    rowmap = Mat%getRowMap()
+    do irow=1,numrow
+       gblrow = rowmap%getGlobalElement(irow)
+       TEST_NOTHROW(call Mat%getGlobalRowView(gblrow, view_cols, view_vals))
+
+       ! Check the results row by row
+       call Tpetra_CrsMatrix_GetTestMatrixRow_A(comm, irow, gblrow, compare_cols, compare_vals, nnz)
+       TEST_FLOATING_ARRAY_EQUALITY(view_vals, compare_vals, epsilon(0.d0))
+       TEST_ARRAY_EQUALITY(view_cols, compare_cols)
+       deallocate(compare_cols, compare_vals)
+    enddo
+
+    nullify(view_cols, view_vals)
+    call Mat%release();  TEST_IERR()
+    call rowmap%release();  TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_GetGlobalRowView")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_GetGlobalRowView)
+
+  ! ------------------------------getProfileType------------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getProfileType)
+    type(TpetraCrsMatrix) :: Mat
+
+    OUT0("Starting TpetraCrsMatrix_getProfileType!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+
+    ! This test fails if fillComplete is called
+    !call Mat%fillComplete()
+
+    TEST_ASSERT(Mat%getProfileType() == TpetraStaticProfile)
+
+    call Mat%release();  TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getProfileType!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getProfileType)
+
+  ! -----------------------------getFrobeniusNorm----------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getFrobeniusNorm)
+    type(TpetraCrsMatrix) :: Mat
+    real(mag_type) :: fresult, fnorm
+
+    OUT0("Starting TpetraCrsMatrix_getFrobeniusNorm!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+
+    fnorm = sqrt(real(comm%getSize()*test_matrix_num_local(), kind=scalar_type))
+    TEST_NOTHROW(fresult=Mat%getFrobeniusNorm())
+    TEST_ASSERT(fresult==fnorm)
+
+    call Mat%release();  TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getFrobeniusNorm!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getFrobeniusNorm)
+
+  ! -------------------------------getAllValues------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getAllValues)
+    type(TpetraMap) :: colmap
+    type(TpetraCrsMatrix) :: Mat
+    integer :: numrow, numnnz, ii
+    integer(size_type), dimension(:), allocatable :: row_ptrs, rp_res
+    integer(int_type), dimension(:), allocatable :: colind, col_res, col_gbl
+    real(scalar_type), dimension(:), allocatable :: values, val_res
+
+    OUT0("Starting TpetraCrsMatrix_getAllValues!")
+
+    call TPetra_CrsMatrix_CreateTestMatrix_A(comm, Mat)
+    call Mat%fillComplete()
+
+    numrow = Mat%getNodeNumRows()
+    numnnz = Mat%getNodeNumEntries()
+    allocate(row_ptrs(numrow+1),rp_res(numrow+1))
+    allocate(colind(numnnz),col_res(numnnz),col_gbl(numnnz))
+    allocate(values(numnnz),val_res(numnnz))
+
+    call Mat%getAllValues(row_ptrs, colind, values)
+
+    ! getAllValues returns the local indexing of column -- convert to global
+    ! for the comparison
+    colmap=Mat%getColMap()
+    do ii = 1,numnnz
+       col_gbl(ii) = colmap%getGlobalElement(colind(ii))
+    enddo
+
+    !---------------------------------------------------------------
+    ! CHECK results
+    !---------------------------------------------------------------
+    ! Get expected results
+    call TPetra_CrsMatrix_getTestMatrixResults(comm, rp_res, col_res, val_res)
+
+    TEST_ARRAY_EQUALITY(row_ptrs, rp_res)
+    TEST_FLOATING_ARRAY_EQUALITY(values, val_res, epsilon(0.d0))
+
+    ! column indices are often reordered so test the sum's of the global indices
+    ! this is why global indices are preferred -- larger sums less likely if err
+    TEST_EQUALITY(SUM(col_gbl), SUM(col_res))
+
+    deallocate(row_ptrs, colind, values, rp_res, col_res, val_res, col_gbl)
+
+    call colmap%release();  TEST_IERR()
+    call Mat%release();  TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_getAllValues!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getAllValues)
+
+  ! -------------------------------setAllValues------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_setAllValues)
+    type(TpetraCrsMatrix) :: Mat, mat_compare
+    type(TpetraMap) :: map, colmap
+    integer :: numrow, numnnz, ii, id
+    integer(global_ordinal_type), dimension(:), allocatable :: rowptr, rowchk
+    integer, dimension(:), allocatable :: ind, indchk, indgbl, indlcl
+    real(mag_type), dimension(:), allocatable :: vals, valchk
+
+    OUT0("Starting TpetraCrsMatrix_setAllValues!")
+
+    map = TpetraMap(TPETRA_GLOBAL_INVALID, test_matrix_num_row(), comm)
+    Mat = TpetraCrsMatrix(map, map, test_matrix_max_entries_per_row(), TpetraStaticProfile)
+
+    ! Like getAllValues use the TestMatrix.
+    call TPetra_CrsMatrix_CreateTestMatrix_A(comm, mat_compare)
+    call mat_compare%fillComplete()
+
+    numrow = mat_compare%getNodeNumRows()
+    numnnz = mat_compare%getNodeNumEntries()
+    allocate(rowptr(numrow+1), rowchk(numrow+1))
+    allocate(indgbl(numnnz), ind(numnnz), indchk(numnnz), indlcl(numnnz))
+    allocate(vals(numnnz), valchk(numnnz))
+
+    call TPetra_CrsMatrix_getTestMatrixResults(comm, rowchk, indchk, valchk)
+
+    ! setAllValues wants local indicies; helper returns globals so use ColMap to convert
+    colmap=Mat%getColMap()
+    do ii = 1,numnnz
+       indlcl(ii) = colmap%getLocalElement(int(indchk(ii), global_ordinal_type))
+    enddo
+
+    TEST_NOTHROW(call Mat%setAllValues(rowchk, indlcl, valchk))
+
+
+    !---------------------------------------------------------------
+    ! CHECK results
+    !---------------------------------------------------------------
+    call Mat%getAllValues(rowptr, ind, vals)
+    TEST_ARRAY_EQUALITY(rowptr, rowchk)
+    TEST_FLOATING_ARRAY_EQUALITY(vals, valchk, epsilon(0.d0))
+
+    deallocate(rowptr, ind, vals, rowchk, indchk, valchk, indgbl, indlcl)
+    call Mat%release(); TEST_IERR()
+    call colmap%release(); TEST_IERR()
+    call Map%release(); TEST_IERR()
+    call mat_compare%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_setAllValues!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_setAllValues)
+
+  ! ----------------------------insertGlobalValues---------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_insertGlobalValues)
+    type(TpetraMap) :: colmap
+    type(TpetraCrsMatrix) :: Mat
+    integer :: numnnz, ii
+    integer :: numrow = 4
+    integer(size_type), dimension(:), allocatable :: row_ptrs, rp_res
+    integer(int_type), dimension(:), allocatable :: colind, col_res, col_gbl
+    real(scalar_type), dimension(:), allocatable :: values, val_res
+    type(TpetraMap) :: map
+    integer :: nnz, irow
+    integer(global_ordinal_type) :: gblrow
+    integer(global_ordinal_type), allocatable :: cols(:)
+    real(scalar_type), allocatable :: vals(:)
+
+    OUT0("Starting TpetraCrsMatrix_insertGlobalValues!")
+
+    ! create a Map and matrix
+    map = TpetraMap(TPETRA_GLOBAL_INVALID, numrow, comm)
+
+    Mat = TpetraCrsMatrix(map, test_matrix_max_entries_per_row(), TpetraStaticProfile)
+
+    ! The test setup TPetra_CrsMatrix_CreateTestMatrix is essentially
+    ! a test of insertGlobalValues but we'd like to have it appear
+    ! explicitly in this test so we duplicate the code here.
+    do irow=1,numrow
+      call Tpetra_CrsMatrix_GetTestMatrixRow_A(comm, irow, gblrow, cols, vals, nnz)
+      call Mat%insertGlobalValues(gblrow, cols, vals)
+      deallocate(cols,vals)
+    enddo
+
+    !---------------------------------------------------------------
+    ! Now read values and check them
+    !---------------------------------------------------------------
+    call Mat%fillComplete()
+
+    numrow = Mat%getNodeNumRows()
+    numnnz = Mat%getNodeNumEntries()
+    allocate(row_ptrs(numrow+1),rp_res(numrow+1))
+    allocate(colind(numnnz),col_res(numnnz),col_gbl(numnnz))
+    allocate(values(numnnz),val_res(numnnz))
+
+    call Mat%getAllValues(row_ptrs, colind, values)
+
+    ! getAllValues returns the local indexing of column -- convert to global
+    ! for the comparison
+    colmap=Mat%getColMap()
+    do ii = 1,numnnz
+       col_gbl(ii) = colmap%getGlobalElement(colind(ii))
+    enddo
+
+    !---------------------------------------------------------------
+    ! CHECK results
+    !---------------------------------------------------------------
+    ! Get expected results
+    call TPetra_CrsMatrix_getTestMatrixResults(comm, rp_res, col_res, val_res)
+
+    TEST_ARRAY_EQUALITY(row_ptrs, rp_res)
+    TEST_FLOATING_ARRAY_EQUALITY(values, val_res, epsilon(0.d0))
+
+    ! column indices are often reordered so test the sum's of the global indices
+    ! this is why global indices are preferred -- larger sums less likely if err
+    TEST_EQUALITY(SUM(col_gbl), SUM(col_res))
+
+    deallocate(row_ptrs, colind, values, rp_res, col_res, val_res, col_gbl)
+    call map%release();  TEST_IERR()
+    call colmap%release();  TEST_IERR()
+    call Mat%release();  TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_insertGlobalValues!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_insertGlobalValues)
+
+  ! ----------------------------insertLocalValues----------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_insertLocalValues)
+    type(TpetraMap) :: rowMap, colMap
+    integer(int_type) :: lclNumRows, lclNumCols, lclRow
+    integer(global_ordinal_type) gblNumRows
+    integer(int_type) :: numProcs
+    integer(int_type), dimension(:), allocatable :: lclColInds
+    real(mag_type), allocatable :: vals(:)
+    integer(int_type), dimension(:), allocatable :: curLclColInds
+    real(mag_type), allocatable :: curVals(:)
+    type(TpetraCrsMatrix) :: Mat
+    integer(size_type) :: numEnt=0
+
+    ! Note that this test is currently identical to TpetraCrsMatrix_getLocalRowCopy
+    ! becuase they both test getLocalRowCopy and insertLocalValues
+
+    OUT0("Starting TpetraCrsMatrix_insertLocalValues!")
+
+    numProcs = comm%getSize()
+    lclNumRows = 10
+    gblNumRows = lclNumRows * numProcs
+    rowMap = TpetraMap(gblNumRows, lclNumRows, comm)
+
+    ! We need a locally indexed matrix to test getLocalRowCopy, so we
+    ! need a column Map.  It can be the same as the row Map in this
+    ! case, since we're not testing global effects.
+    colMap = rowMap
+    lclNumCols = lclNumRows
+
+    ! Leave room for three locally owned entries per row.
+    ! We will only fill in two entries per row.
+    Mat = TpetraCrsMatrix(rowMap, colMap, test_matrix_max_entries_per_row(), TpetraStaticProfile)
+
+    allocate(lclColInds(2))
+    allocate(vals(2))
+
+    do lclRow = 1, lclNumRows
+      lclColInds(1) = 1 + modulo(lclRow + 0, lclNumCols)
+      lclColInds(2) = 1 + modulo(lclRow + 1, lclNumCols)
+
+      vals(1) = lclColInds(1)
+      vals(2) = lclColInds(2)
+
+      TEST_NOTHROW(call Mat%insertLocalValues(lclRow, lclColInds, vals))
+    end do
+
+    TEST_ASSERT(.not. Mat%isFillComplete());
+
+    ! Make the arrays bigger than necessary, just to make sure that
+    ! the methods behave correctly.
+    allocate(curLclColInds(5))
+    allocate(curVals(5))
+
+    do lclRow = 1, lclNumRows
+      TEST_NOTHROW(call Mat%getLocalRowCopy(lclRow, curLclColInds, curVals, numEnt))
+      TEST_EQUALITY(int(numEnt), 2)
+
+      TEST_EQUALITY(curLclColInds(1), 1 + modulo(lclRow + 0, lclNumCols));
+      TEST_EQUALITY(curLclColInds(2), 1 + modulo(lclRow + 1, lclNumCols));
+
+      TEST_EQUALITY(int(curVals(1)), curLclColInds(1));
+      TEST_EQUALITY(int(curVals(2)), curLclColInds(2));
+    end do
+
+    call Mat%release(); TEST_IERR()
+    call rowMap%release(); TEST_IERR()
+    call colMap%release(); TEST_IERR()
+    deallocate(lclColInds)
+    deallocate(vals)
+    deallocate(curLclColInds)
+    deallocate(curVals)
+
+    OUT0("Finished TpetraCrsMatrix_insertLocalValues!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_insertLocalValues)
+
+  ! ---------------------------replaceGlobalValues---------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_replaceGlobalValues)
+    type(TpetraCrsMatrix) :: Mat
+    integer :: irow, numvalid
+    integer(global_ordinal_type) :: base, gblrow, cols(1)
+    real(mag_type) :: vals(1)=[2.]
+    integer :: lclrow
+
+    OUT0("Starting TpetraCrsMatrix_replaceGlobalValues!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+
+    base = test_matrix_num_local() * comm%getRank()
+    do irow = 1, test_matrix_num_local()
+      gblrow = base + int(irow, kind=global_ordinal_type)
+      cols(1) = gblrow
+      TEST_NOTHROW(numvalid = Mat%replaceGlobalValues(gblrow, cols, vals))
+      ! Only one entry changes per iteration, and numvalid indicates how many
+      ! substitutions have occured
+      TEST_EQUALITY(numvalid, 1)
+    end do
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_replaceGlobalValues!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_replaceGlobalValues)
+
+  ! ------------------------------setAllToScalar------------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_setAllToScalar)
+    type(TpetraCrsMatrix) :: Mat
+    type(TpetraMap) :: rowmap
+    integer :: lclRow, ii
+    real(mag_type), allocatable :: vals(:)
+    integer(global_ordinal_type) :: gblRow, numEnt = 0
+    integer(global_ordinal_type), allocatable :: gblColInds(:)
+
+    OUT0("Starting TpetraCrsMatrix_setAllToScalar!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    rowmap = Mat%getRowMap()
+
+    TEST_NOTHROW(call Mat%setAllToScalar(real(2,mag_type)))
+    call Mat%fillComplete()
+    allocate(gblColInds(test_matrix_num_local()), vals(test_matrix_num_local()))
+
+    do lclRow = 1, test_matrix_num_local()
+      gblRow = rowMap%getGlobalElement(lclRow)
+      TEST_NOTHROW(call Mat%getGlobalRowCopy(gblRow, gblColInds, vals, numEnt))
+
+      do ii = 1, numEnt
+        TEST_FLOATING_EQUALITY(vals(ii), real(2, mag_type), epsilon(real(2, mag_type)))
+      end do
+    end do
+
+    call Mat%release(); TEST_IERR()
+    call rowmap%release(); TEST_IERR()
+    deallocate(vals, gblColInds)
+    OUT0("Finished TpetraCrsMatrix_setAllToScalar!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_setAllToScalar)
+
+  ! ----------------------------------scale----------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_scale)
+    type(TpetraCrsMatrix) :: Mat
+    real(mag_type) :: norm, norm_s
+
+    OUT0("Starting TpetraCrsMatrix_scale!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
+    norm = Mat%getFrobeniusNorm()
+
+    call Mat%resumeFill()
+    TEST_NOTHROW(call Mat%scale(real(2.0, mag_type)))
+    call Mat%fillComplete()
+    norm_s = Mat%getFrobeniusNorm()
+
+    !Norm properties: Scaling matrix by 2 should scale norm by 2
+    TEST_FLOATING_EQUALITY(norm_s, 2.0_mag_type * norm, epsilon(norm))
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_scale!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_scale)
+
+  ! ------------------------------globalAssemble------------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_globalAssemble)
+    type(TpetraCrsMatrix) :: Mat
+
+    OUT0("Starting TpetraCrsMatrix_globalAssemble!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
+
+    TEST_THROW(call Mat%globalAssemble())
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_globalAssemble!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_globalAssemble)
+
+  ! ------------------------------replaceColMap------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_replaceColMap)
+    type(TpetraMap) :: map, newcolmap
+    type(TpetraCrsMatrix) :: mat
+    integer(size_type), parameter :: ione=1
+
+    OUT0("Starting TpetraCrsMatrix_replaceColMap")
+
+    map = TpetraMap(TPETRA_GLOBAL_INVALID, test_matrix_num_local(), comm); TEST_IERR()
+    mat = TpetraCrsMatrix(map, ione, TpetraStaticProfile)
+
+    newcolmap = TpetraMap(TPETRA_GLOBAL_INVALID, test_matrix_num_local()-1, comm); TEST_IERR()
+
+    call mat%replaceColMap(newcolmap); TEST_IERR()
+
+    call mat%release(); TEST_IERR()
+    call map%release(); TEST_IERR()
+    call newcolmap%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_replaceColMap")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_replaceColMap)
+
+  ! -----------------------removeEmptyProcessesInPlace------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_removeEmptyProcessesInPlace)
+    type(TpetraCrsMatrix) :: mat
+    type(TpetraMap) :: map
+    integer(size_type), parameter :: ione=1
+    integer :: lnum_local=3
+
+    OUT0("Starting TpetraCrsMatrix_removeEmptyProcessesInPlace")
+
+    map = TpetraMap(TPETRA_GLOBAL_INVALID, lnum_local, comm); TEST_IERR()
+    mat = TpetraCrsMatrix(map, ione, TpetraStaticProfile)
+
+    call mat%removeEmptyProcessesInPlace(map); TEST_IERR()
+
+    call map%release(); TEST_IERR()
+    call mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_removeEmptyProcessesInPlace")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_removeEmptyProcessesInPlace)
+
+  ! --------------------------------hasColMap--------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_hasColMap)
+    type(TpetraCrsMatrix) :: Mat
+
+    OUT0("Starting TpetraCrsMatrix_hasColMap!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
+
+    TEST_ASSERT(Mat%hasColMap())
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_hasColMap!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_hasColMap)
+
+  ! -----------------------------isLocallyIndexed----------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_isLocallyIndexed)
+    type(TpetraCrsMatrix) :: Mat
+
+    OUT0("Starting TpetraCrsMatrix_isLocallyIndexed!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
+
+    TEST_ASSERT(Mat%isLocallyIndexed())
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_isLocallyIndexed!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_isLocallyIndexed)
+
+  ! ----------------------------isGloballyIndexed----------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_isGloballyIndexed)
+    type(TpetraCrsMatrix) :: Mat
+
+    OUT0("Starting TpetraCrsMatrix_isGloballyIndexed!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+
+    TEST_ASSERT(Mat%isGloballyIndexed())
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_isGloballyIndexed!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_isGloballyIndexed)
+
+  ! ------------------------------isFillComplete------------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_isFillComplete)
+    type(TpetraCrsMatrix) :: Mat
+
+    OUT0("Starting TpetraCrsMatrix_isFillComplete!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
+
+    TEST_ASSERT(Mat%isFillComplete())
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_isFillComplete!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_isFillComplete)
+
+  ! -------------------------------isFillActive------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_isFillActive)
+    type(TpetraCrsMatrix) :: Mat
+
+    OUT0("Starting TpetraCrsMatrix_isFillActive!")
+
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+
+    TEST_ASSERT(Mat%isFillActive())
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_isFillActive!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_isFillActive)
+
   ! ----------------------------isStorageOptimized---------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_isStorageOptimized)
-    type(TpetraCrsMatrix) :: Obj
+    type(TpetraCrsMatrix) :: mat
+
     OUT0("Starting TpetraCrsMatrix_isStorageOptimized")
 
-    success = .false.
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
 
-    !Obj = TpetraCrsMatrix(); TEST_IERR()
-    !fresult = Obj%isStorageOptimized(); TEST_IERR()
+    TEST_ASSERT(mat%isStorageOptimized())
 
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsMatrix_isStorageOptimized: Test not yet implemented'
+    call mat%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsMatrix_isStorageOptimized")
 
@@ -554,17 +1559,23 @@ contains
 
   ! ------------------------------isStaticGraph------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_isStaticGraph)
-    type(TpetraCrsMatrix) :: Obj
+    type(TpetraMap) :: map
+    type(TpetraCrsMatrix) :: mat
+    type(TpetraCrsGraph) :: graph
+    integer(size_type), parameter :: ione=1
+
     OUT0("Starting TpetraCrsMatrix_isStaticGraph")
 
-    success = .false.
+    map = TpetraMap(TPETRA_GLOBAL_INVALID, test_matrix_num_local(), comm); TEST_IERR()
+    graph = TpetraCrsGraph(Map, Map, ione, TpetraStaticProfile)
+    call graph%fillComplete()
+    mat = TpetraCrsMatrix(graph)
 
-    !Obj = TpetraCrsMatrix(); TEST_IERR()
-    !fresult = Obj%isStaticGraph(); TEST_IERR()
+    TEST_ASSERT(mat%isStaticGraph())
 
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsMatrix_isStaticGraph: Test not yet implemented'
+    call map%release(); TEST_IERR()
+    call mat%release(); TEST_IERR()
+    call graph%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsMatrix_isStaticGraph")
 
@@ -572,244 +1583,203 @@ contains
 
   ! -----------------------------supportsRowViews----------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_supportsRowViews)
-    type(TpetraCrsMatrix) :: Obj
+    type(TpetraCrsMatrix) :: Mat
+
     OUT0("Starting TpetraCrsMatrix_supportsRowViews")
 
-    success = .false.
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
 
-    !Obj = TpetraCrsMatrix(); TEST_IERR()
-    !fresult = Obj%supportsRowViews(); TEST_IERR()
+    TEST_ASSERT(Mat%supportsRowViews())
 
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsMatrix_supportsRowViews: Test not yet implemented'
+    call Mat%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsMatrix_supportsRowViews")
 
   END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_supportsRowViews)
-#endif
 
-  ! -----------------------------getGlobalRowView----------------------------- !
-  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_GetGlobalRowView)
+  ! ----------------------------hasTransposeApply----------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_hasTransposeApply)
+    type(TpetraCrsMatrix) :: Mat
 
-    type(TpetraMap) :: rowmap, colmap
-    type(TpetraCrsMatrix) :: A
-    type(ParameterList) :: params
-    integer(TpetraProfileType) :: pftype
-    integer(size_type) :: num_images, my_image_id, numentries
-    integer :: nnz
-    integer :: T, i
-    integer, parameter :: lclrow=1
-    logical :: opt_storage
-    real(scalar_type) :: scopy(4)
-    integer :: lcopy(4)
-    integer(global_ordinal_type) :: gcopy(4)
-    integer(global_ordinal_type), pointer :: cgptr(:) => NULL()
-    real(scalar_type), pointer :: csptr(:) => NULL()
-    integer(global_ordinal_type) :: gblrow
-    integer, allocatable :: linds(:)
-    integer(global_ordinal_type), allocatable :: ginds(:), mask(:)
-    real(scalar_type), allocatable :: values(:)
-    ! ------------------------------------------------------------------------ !
+    OUT0("Starting TpetraCrsMatrix_hasTransposeApply!")
 
-    OUT0("Starting TpetraCrsMatrix_GetGlobalRowView")
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
+
+    TEST_ASSERT(Mat%hasTransposeApply())
+
+    call Mat%release(); TEST_IERR()
+
+    OUT0("Finished TpetraCrsMatrix_hasTransposeApply!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_hasTransposeApply)
+
+  ! -------------------------------description-------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_description)
+    type(TpetraCrsMatrix) :: Mat
+    character(kind=C_CHAR, len=:), allocatable :: description
+    character(kind=C_CHAR, len=200) :: desc_res
+    character(kind=C_CHAR, len=2) :: str_size
+    integer :: num_images
+
+    OUT0("Starting TpetraCrsMatrix_description!")
 
     num_images = comm%getSize()
-    my_image_id = comm%getRank()
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
 
-    if (num_images < 2) return
+    TEST_NOTHROW(description = Mat%description())
 
-    ! create a Map, one row per processor
-    rowmap = TpetraMap(TPETRA_GLOBAL_INVALID, 1, comm); TEST_IERR()
+    ! Test against known result
+    ! string processing in fortran:
+    !  FORTRAN was the language of choice for the same reason that three-legged races are popular. - -  Kernighan
+    write(str_size,fmt='(i2.2)') num_images*10
+    desc_res="Tpetra::CrsMatrix (Kokkos refactor): {isFillComplete: true, global dimensions: ["
+    desc_res=TRIM(desc_res)//str_size//', '//str_size//'], global number of entries: '//str_size//'}'
+    TEST_EQUALITY(TRIM(description),TRIM(desc_res))
 
-    gblrow = rowmap%getGlobalElement(1);
+    call Mat%release(); TEST_IERR()
 
-    ! specify the column map to control ordering
-    ! construct tridiagonal graph
-    if (gblrow == 1) then
-      nnz = 2
-      allocate(ginds(nnz));
-      ginds = [gblrow, gblrow+1]
-    else if (gblrow == num_images) then
-      nnz = 2
-      allocate(ginds(nnz));
-      ginds = [gblrow-1, gblrow]
-    else
-      nnz = 3
-      allocate(ginds(nnz));
-      ginds = [gblrow-1, gblrow, gblrow+1]
-    end if
-    allocate(linds(nnz))
-    forall(i=1:nnz) linds(i)=i
+    OUT0("Finished TpetraCrsMatrix_description!")
 
-    allocate(values(nnz))
-    values = 1.0d0
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_description)
 
-    ! Create column map
-    colmap = TpetraMap(TPETRA_GLOBAL_INVALID, ginds, comm);
+  ! --------------------------computeGlobalConstants-------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_computeGlobalConstants)
+    type(TpetraCrsMatrix) :: Mat
+    character(kind=C_CHAR, len=:), allocatable :: description
 
-    params = ParameterList("ANONYMOUS")
+    OUT0("Starting TpetraCrsMatrix_computeGlobalConstants!")
 
-    do T = 0, 1
-      pftype = TpetraStaticProfile
-      opt_storage = IAND(T, 2) == 2
-      call params%set("Optimize Storage", opt_storage)
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
 
-      ! only allocate as much room as necessary
-      numentries = int(nnz, kind=size_type)
-      A = TpetraCrsMatrix(rowmap, colmap, numentries, pftype)
+    TEST_NOTHROW(call Mat%computeGlobalConstants())
 
-      ! at this point, the graph has not allocated data as global or local, so
-      ! we can do views/copies for either local or global
-      call A%getLocalRowCopy(lclrow, lcopy, scopy, numentries)
-      !call A%getLocalRowView(lclrow, clview, csptr)
-      call A%getGlobalRowCopy(gblrow, gcopy, scopy, numentries)
+    call Mat%release(); TEST_IERR()
 
-      call A%insertGlobalValues(gblrow, ginds, values)
+    OUT0("Finished TpetraCrsMatrix_computeGlobalConstants!")
 
-      ! check values before calling fillComplete
-      allocate(mask(nnz))
-      mask = -1
-      call A%getGlobalRowView(gblrow, cgptr, csptr)
-      do i=1, nnz;
-        where(ginds(i)==cgptr) mask = i
-      end do
-      TEST_ASSERT((.not. any(mask==-1)))
-      TEST_ARRAY_EQUALITY(cgptr(mask), ginds)
-      TEST_FLOATING_ARRAY_EQUALITY(csptr(mask), values, epsilon(0.d0))
-      deallocate(mask)
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_computeGlobalConstants)
 
-      call A%fillComplete(params);
+  ! ---------------------------haveGlobalConstants---------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_haveGlobalConstants)
+    type(TpetraCrsMatrix) :: Mat
+    character(kind=C_CHAR, len=:), allocatable :: description
 
-      ! check for throws and no-throws/values
-      TEST_THROW(call A%getGlobalRowView(gblrow, cgptr, csptr))
+    OUT0("Starting TpetraCrsMatrix_haveGlobalConstants!")
 
-      !TEST_NOTHROW(call A%getLocalRowView(lclrow, clview, csptr))
-      !TEST_ARRAY_EQUALITY(clview, linds)
-      !TEST_FLOATING_ARRAY_EQUALITY(csptr, values, epsilon(0.d0))
+    call TPetra_CrsMatrix_CreateIdentity(comm, Mat)
+    call Mat%fillComplete()
 
-      TEST_NOTHROW(call A%getLocalRowCopy(lclrow, lcopy, scopy, numentries))
-      TEST_ARRAY_EQUALITY(lcopy(1:numentries), linds)
-      TEST_FLOATING_ARRAY_EQUALITY(scopy(1:numentries), values, epsilon(0.d0))
+    call Mat%computeGlobalConstants()
+    TEST_ASSERT(Mat%haveGlobalConstants())
 
-      TEST_NOTHROW(call A%getGlobalRowCopy(gblrow, gcopy, scopy, numentries) );
-      TEST_ARRAY_EQUALITY(gcopy(1:numentries), ginds)
-      TEST_FLOATING_ARRAY_EQUALITY(scopy(1:numentries), values, epsilon(0.d0))
+    call Mat%release(); TEST_IERR()
 
-      call A%release()
+    OUT0("Finished TpetraCrsMatrix_haveGlobalConstants!")
 
-    end do
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_haveGlobalConstants)
 
-    call rowmap%release()
-    call colmap%release()
+  ! -----------------------replaceDomainMapAndImporter------------------------ !
+  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_replaceDomainMapAndImporter)
+    type(TpetraCrsMatrix) :: mat
+    type(TpetraMap) :: newdomainmap, newcolmap
+    type(TpetraImport) :: newimporter
+    integer(global_ordinal_type) :: num_global
 
-    deallocate(linds); deallocate(ginds); deallocate(values)
+    OUT0("Starting TpetraCrsMatrix_replaceDomainMapAndImporter")
 
-    OUT0("Finished TpetraCrsMatrix_GetGlobalRowView")
+    call TPetra_CrsMatrix_CreateIdentity(comm, mat)
+    call mat%fillComplete()
 
-  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_GetGlobalRowView)
+    num_global = 5*comm%getSize()
+    newdomainmap = TpetraMap(num_global, comm); TEST_IERR()
+    newcolmap =  mat%getColMap(); TEST_IERR()
+    newimporter = TpetraImport(newdomainmap, newcolmap ); TEST_IERR()
 
-#if 0
-  ! ----------------------------getLocalRowViewRaw---------------------------- !
-  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getLocalRowViewRaw)
-    type(TpetraCrsMatrix) :: Obj
-    integer :: lclrow
-    integer :: nument
-    type(C_PTR) :: lclcolinds
-    type(C_PTR) :: vals
-    OUT0("Starting TpetraCrsMatrix_getLocalRowViewRaw")
+    TEST_NOTHROW(call mat%replaceDomainMapAndImporter(newdomainmap, newimporter))
 
-    success = .false.
+    call newimporter%release(); TEST_IERR()
+    call newdomainmap%release(); TEST_IERR()
+    call newcolmap%release(); TEST_IERR()
+    call mat%release(); TEST_IERR()
 
-    lclrow = 0
-    nument = 0
-    !lclcolinds = xxx(); TEST_IERR()
-    !vals = xxx(); TEST_IERR()
-    !Obj = TpetraCrsMatrix(); TEST_IERR()
-    !fresult = Obj%getLocalRowViewRaw(lclrow, nument, lclcolinds, vals); TEST_IERR()
+    OUT0("Finished TpetraCrsMatrix_replaceDomainMapAndImporter")
 
-    !call lclcolinds%release(); TEST_IERR()
-    !call vals%release(); TEST_IERR()
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsMatrix_getLocalRowViewRaw: Test not yet implemented'
-
-    OUT0("Finished TpetraCrsMatrix_getLocalRowViewRaw")
-
-  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_getLocalRowViewRaw)
+  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_replaceDomainMapAndImporter)
 
   ! -------------------------------gaussSeidel-------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_gaussSeidel)
-    type(TpetraCrsMatrix) :: Obj
+    type(TpetraMap) :: Map, row_map, tmp_map
+    type(TeuchosComm) :: tcomm
+    type(TpetraCrsMatrix) :: Mat
     type(TpetraMultiVector) :: b
     type(TpetraMultiVector) :: x
     type(TpetraMultiVector) :: d
     real(scalar_type) :: dampingfactor
+    real(scalar_type), parameter :: one=1.
+    integer(size_type), parameter :: ione=1
+    integer(size_type), parameter :: num_vecs=1
+    real(mag_type) :: vals(1)=[1.], normb(num_vecs), normx(num_vecs)
+    integer(size_type) :: num_images, my_image_id
+    integer :: irow
+    integer(global_ordinal_type) :: base, gblrow, cols(1)
     integer(kind(TpetraESweepDirection)) :: direction
     integer(C_INT) :: numsweeps
+
     OUT0("Starting TpetraCrsMatrix_gaussSeidel")
 
-    success = .false.
+    my_image_id = comm%getRank()
 
-    !b = TpetraMultiVector(); TEST_IERR()
-    !x = TpetraMultiVector(); TEST_IERR()
-    !d = TpetraMultiVector(); TEST_IERR()
-    dampingfactor = 0
+    ! create a Map
+    Map = TpetraMap(TPETRA_GLOBAL_INVALID, test_matrix_num_local(), comm); TEST_IERR()
+
+    ! create the identity matrix
+    base = test_matrix_num_local() * my_image_id
+    Mat = TpetraCrsMatrix(Map, ione, TpetraStaticProfile)
+    do irow = 1, test_matrix_num_local()
+      gblrow = base + int(irow, kind=global_ordinal_type)
+      cols(1) = gblrow
+      vals(1) = one
+      call Mat%insertGlobalValues(gblrow, cols, vals)
+    end do
+    call mat%fillComplete()
+
+    b = TpetraMultiVector(Map, num_vecs); TEST_IERR()
+    call b%randomize(); TEST_IERR()
+    x = TpetraMultiVector(Map, num_vecs); TEST_IERR()
+    call x%randomize(); TEST_IERR()
+    d = TpetraMultiVector(Map, num_vecs); TEST_IERR()
+    call d%putScalar(-1.0_scalar_type)  ! Inverse diagonal
+    dampingfactor = 0.04
     direction = 0
-    numsweeps = 0
-    !Obj = TpetraCrsMatrix(); TEST_IERR()
-    !call Obj%gaussSeidel(b, x, d, dampingfactor, direction, numsweeps); TEST_IERR()
+    numsweeps = 4
 
-    !call b%release(); TEST_IERR()
-    !call x%release(); TEST_IERR()
-    !call d%release(); TEST_IERR()
-    !call Obj%release(); TEST_IERR()
+    call b%norm2(normb)
+    call x%norm2(normx)
+    !write(*,*) 'Before iterating: normx= ', normx,' normb ', normb
 
-    write(*,*) 'TpetraCrsMatrix_gaussSeidel: Test not yet implemented'
+    call Mat%gaussSeidel(b, x, d, dampingfactor, direction, numsweeps); TEST_IERR()
+
+    call b%norm2(normb)
+    call x%norm2(normx)
+    !write(*,*) 'After iterating: normx= ', normx,' normb ', normb
+
+    call b%release(); TEST_IERR()
+    call x%release(); TEST_IERR()
+    call d%release(); TEST_IERR()
+    call Mat%release(); TEST_IERR()
+    call Map%release(); TEST_IERR()
 
     OUT0("Finished TpetraCrsMatrix_gaussSeidel")
 
   END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_gaussSeidel)
 
-  ! ---------------------------reorderedGaussSeidel--------------------------- !
-  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_reorderedGaussSeidel)
-    type(TpetraCrsMatrix) :: Obj
-    type(TpetraMultiVector) :: b
-    type(TpetraMultiVector) :: x
-    type(TpetraMultiVector) :: d
-    !type(TeuchosArrayViewInt) :: rowindices
-    real(scalar_type) :: dampingfactor
-    integer(kind(TpetraESweepDirection)) :: direction
-    integer(C_INT) :: numsweeps
-    OUT0("Starting TpetraCrsMatrix_reorderedGaussSeidel")
-
-    success = .false.
-
-    !b = TpetraMultiVector(); TEST_IERR()
-    !x = TpetraMultiVector(); TEST_IERR()
-    !d = TpetraMultiVector(); TEST_IERR()
-    !rowindices = xxx(); TEST_IERR()
-    dampingfactor = 0
-    direction = 0
-    numsweeps = 0
-    !Obj = TpetraCrsMatrix(); TEST_IERR()
-    !call Obj%reorderedGaussSeidel(b, x, d, rowindices, dampingfactor, direction, numsweeps); TEST_IERR()
-
-    !call b%release(); TEST_IERR()
-    !call x%release(); TEST_IERR()
-    !call d%release(); TEST_IERR()
-    !call rowindices%release(); TEST_IERR()
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsMatrix_reorderedGaussSeidel: Test not yet implemented'
-
-    OUT0("Finished TpetraCrsMatrix_reorderedGaussSeidel")
-
-  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_reorderedGaussSeidel)
-
   ! -----------------------------gaussSeidelCopy------------------------------ !
   FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_gaussSeidelCopy)
-    type(TpetraCrsMatrix) :: Obj
+    type(TpetraCrsMatrix) :: Mat
     type(TpetraMultiVector) :: x
     type(TpetraMultiVector) :: b
     type(TpetraMultiVector) :: d
@@ -828,13 +1798,13 @@ contains
     direction = 0
     numsweeps = 0
     zeroinitialguess = .false.
-    !Obj = TpetraCrsMatrix(); TEST_IERR()
-    !call Obj%gaussSeidelCopy(x, b, d, dampingfactor, direction, numsweeps, zeroinitialguess); TEST_IERR()
+    !Mat = TpetraCrsMatrix(); TEST_IERR()
+    !call Mat%gaussSeidelCopy(x, b, d, dampingfactor, direction, numsweeps, zeroinitialguess); TEST_IERR()
 
     !call x%release(); TEST_IERR()
     !call b%release(); TEST_IERR()
     !call d%release(); TEST_IERR()
-    !call Obj%release(); TEST_IERR()
+    !call Mat%release(); TEST_IERR()
 
     write(*,*) 'TpetraCrsMatrix_gaussSeidelCopy: Test not yet implemented'
 
@@ -842,110 +1812,4 @@ contains
 
   END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_gaussSeidelCopy)
 
-  ! -------------------------reorderedGaussSeidelCopy------------------------- !
-  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_reorderedGaussSeidelCopy)
-    type(TpetraCrsMatrix) :: Obj
-    type(TpetraMultiVector) :: x
-    type(TpetraMultiVector) :: b
-    type(TpetraMultiVector) :: d
-    !type(TeuchosArrayViewInt) :: rowindices
-    real(scalar_type) :: dampingfactor
-    integer(kind(TpetraESweepDirection)) :: direction
-    integer(C_INT) :: numsweeps
-    logical(C_BOOL) :: zeroinitialguess
-    OUT0("Starting TpetraCrsMatrix_reorderedGaussSeidelCopy")
-
-    success = .false.
-
-    !x = TpetraMultiVector(); TEST_IERR()
-    !b = TpetraMultiVector(); TEST_IERR()
-    !d = TpetraMultiVector(); TEST_IERR()
-    !rowindices = xxx(); TEST_IERR()
-    dampingfactor = 0
-    direction = 0
-    numsweeps = 0
-    zeroinitialguess = .false.
-    !Obj = TpetraCrsMatrix(); TEST_IERR()
-    !call Obj%reorderedGaussSeidelCopy(x, b, d, rowindices, dampingfactor, direction, numsweeps, zeroinitialguess); TEST_IERR()
-
-    !call x%release(); TEST_IERR()
-    !call b%release(); TEST_IERR()
-    !call d%release(); TEST_IERR()
-    !call rowindices%release(); TEST_IERR()
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsMatrix_reorderedGaussSeidelCopy: Test not yet implemented'
-
-    OUT0("Finished TpetraCrsMatrix_reorderedGaussSeidelCopy")
-
-  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_reorderedGaussSeidelCopy)
-
-  ! ------------------------------replaceColMap------------------------------- !
-  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_replaceColMap)
-    type(TpetraCrsMatrix) :: Obj
-    type(TpetraMap) :: newcolmap
-    OUT0("Starting TpetraCrsMatrix_replaceColMap")
-
-    success = .false.
-
-    !newcolmap = TpetraMap(); TEST_IERR()
-    !Obj = TpetraCrsMatrix(); TEST_IERR()
-    !call Obj%replaceColMap(newcolmap); TEST_IERR()
-
-    !call newcolmap%release(); TEST_IERR()
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsMatrix_replaceColMap: Test not yet implemented'
-
-    OUT0("Finished TpetraCrsMatrix_replaceColMap")
-
-  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_replaceColMap)
-
-  ! -----------------------replaceDomainMapAndImporter------------------------ !
-  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_replaceDomainMapAndImporter)
-    type(TpetraCrsMatrix) :: Obj
-    type(TpetraMap) :: newdomainmap
-    type(TpetraImport) :: newimporter
-    OUT0("Starting TpetraCrsMatrix_replaceDomainMapAndImporter")
-
-    success = .false.
-
-    !newdomainmap = TpetraMap(); TEST_IERR()
-    !newimporter = TpetraImport(); TEST_IERR()
-    !Obj = TpetraCrsMatrix(); TEST_IERR()
-    !call Obj%replaceDomainMapAndImporter(newdomainmap, newimporter); TEST_IERR()
-
-    !call newdomainmap%release(); TEST_IERR()
-    !call newimporter%release(); TEST_IERR()
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsMatrix_replaceDomainMapAndImporter: Test not yet implemented'
-
-    OUT0("Finished TpetraCrsMatrix_replaceDomainMapAndImporter")
-
-  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_replaceDomainMapAndImporter)
-
-  ! -----------------------removeEmptyProcessesInPlace------------------------ !
-  FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_removeEmptyProcessesInPlace)
-    type(TpetraCrsMatrix) :: Obj
-    type(TpetraMap) :: newmap
-    OUT0("Starting TpetraCrsMatrix_removeEmptyProcessesInPlace")
-
-    success = .false.
-
-    !newmap = TpetraMap(); TEST_IERR()
-    !Obj = TpetraCrsMatrix(); TEST_IERR()
-    !call Obj%removeEmptyProcessesInPlace(newmap); TEST_IERR()
-
-    !call newmap%release(); TEST_IERR()
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraCrsMatrix_removeEmptyProcessesInPlace: Test not yet implemented'
-
-    OUT0("Finished TpetraCrsMatrix_removeEmptyProcessesInPlace")
-
-  END_FORTRILINOS_UNIT_TEST(TpetraCrsMatrix_removeEmptyProcessesInPlace)
-#endif
-
-
-end program test_TpetraCrsMatrix
+end program test_tpetraCrsMatrix

--- a/src/tpetra/test/test_tpetra_crsmatrix_helper.F90
+++ b/src/tpetra/test/test_tpetra_crsmatrix_helper.F90
@@ -1,0 +1,227 @@
+! Copyright 2017-2018, UT-Batte+nnzlle, LLC
+!
+! SPDX-License-Identifier: BSD-3-Clause
+! License-Filename: LICENSE
+!
+! Routines for creating matrices for testing
+! Functions would be more elegant, but rcp errors occurred
+!
+#include "ForTrilinosTpetra_config.hpp"
+module test_Tpetra_crsmatrix_helper
+  use iso_fortran_env
+  use, intrinsic :: iso_c_binding
+  use forteuchos
+  use fortpetra
+
+  implicit none
+
+contains
+  ! helper functions to define simple tests
+  function test_matrix_num_local() result (n)
+    integer :: n
+    n = 10
+  end function test_matrix_num_local
+
+  function test_matrix_num_row() result (n)
+    integer :: n
+    n = 4
+  end function test_matrix_num_row
+
+  function test_matrix_max_entries_per_row() result (n)
+    integer(size_type) :: n
+    n = 3
+  end function test_matrix_max_entries_per_row
+
+  ! ----------------------- Create Identity Matrix ----------------------------- !
+  !   do not call fillComplete
+  subroutine Tpetra_CrsMatrix_CreateIdentity(comm,Mat)
+    type(TeuchosComm), intent(in) :: comm
+    type(TpetraCrsMatrix), intent(out) :: Mat
+    type(TpetraMap) :: map
+    integer :: irow
+    integer(global_ordinal_type) :: base, gblrow, cols(1)
+    real(mag_type) :: vals(1)=[1.]
+
+    ! create a Map
+    map = TpetraMap(TPETRA_GLOBAL_INVALID, test_matrix_num_local(), comm)
+
+    ! create the identity matrix
+    base = test_matrix_num_local() * comm%getRank()
+    Mat = TpetraCrsMatrix(map, map, 1_size_type, TpetraStaticProfile)
+    do irow = 1, test_matrix_num_local()
+      gblrow = base + int(irow, kind=global_ordinal_type)
+      cols(1) = gblrow
+      vals(1) = 1.d0
+      call Mat%insertGlobalValues(gblrow, cols, vals)
+    end do
+
+    call map%release()
+    return
+  end subroutine Tpetra_CrsMatrix_CreateIdentity
+
+  ! ------------------------------- Create Test Matrix ------------------------- !
+  !   do not call fillComplete
+  !  create the following matrix:
+  !  [2 1           ]
+  !  [1 1 1         ]
+  !  [  1 1 1       ]
+  !  [   . . .      ]
+  !  [     . . .    ]
+  !  [       . . .  ]
+  !  [         1 1 1]
+  !  [           1 2]
+  ! this matrix has an eigenvalue lambda=3, with eigenvector v = [1 ... 1]
+  subroutine Tpetra_CrsMatrix_CreateTestMatrix_A(comm,Mat)
+    type(TeuchosComm), intent(in) :: comm
+    type(TpetraCrsMatrix), intent(out) :: Mat
+    type(TpetraMap) :: map
+    integer(global_ordinal_type), allocatable :: cols(:)
+    real(scalar_type), allocatable :: vals(:)
+    integer :: irow, nnz
+    integer(global_ordinal_type) :: gblrow
+
+    ! create a Map and matrix
+    map = TpetraMap(TPETRA_GLOBAL_INVALID, test_matrix_num_row(), comm)
+
+    ! NOTE -  could consider doing a 2D distribution to teach that
+    !rowmap = TpetraMap(TPETRA_GLOBAL_INVALID, test_matrix_num_row(), comm)
+    !nnz=test_matrix_num_row()()*test_matrix_max_entries_per_row()
+    !colmap = TpetraMap(TPETRA_GLOBAL_INVALID, nnz, comm)
+    !Mat = TpetraCrsMatrix(rowmap, colmap, test_matrix_max_entries_per_row(), TpetraStaticProfile)
+    Mat = TpetraCrsMatrix(map, test_matrix_max_entries_per_row(), TpetraStaticProfile)
+
+    do irow=1,test_matrix_num_row()
+      call Tpetra_CrsMatrix_GetTestMatrixRow_A(comm, irow, gblrow, cols, vals, nnz)
+      call Mat%insertGlobalValues(gblrow, cols, vals)
+      deallocate(cols,vals)
+    enddo
+
+    call map%release()
+
+  return
+  end subroutine Tpetra_CrsMatrix_CreateTestMatrix_A
+
+  ! ------------------------------- Get Test Matrix Results ------------------ !
+  ! Hard-code the results matrices for getAllValues test from the TestMatrix
+  ! routine above
+  subroutine Tpetra_CrsMatrix_getTestMatrixResults(comm, row_ptrs, cols, vals)
+    type(TeuchosComm), intent(in) :: comm
+    integer(size_type), dimension(:), intent(out) :: row_ptrs
+    integer(int_type), dimension(:), intent(out) :: cols
+    real(scalar_type), dimension(:), intent(out) :: vals
+    integer(global_ordinal_type), dimension(:), allocatable :: cols_row
+    real(scalar_type), dimension(:), allocatable :: vals_row
+    integer :: num_images, my_image_id, nnz, irow, idx, i
+    integer(global_ordinal_type) :: gblrow
+
+    num_images = comm%getSize()
+    my_image_id = comm%getRank()
+
+    ! insertMatValues routine above uses global indices for row and cols.
+    ! here we return local row but global indices for column
+    row_ptrs(1)=1
+    do irow=1,test_matrix_num_row()
+      idx=row_ptrs(irow)
+      call Tpetra_CrsMatrix_GetTestMatrixRow_A(comm, irow, gblrow, cols_row, vals_row, nnz)
+      do i=1,nnz
+        cols(idx+i-1) = cols_row(i)
+        vals(idx+i-1) = vals_row(i)
+      enddo
+      deallocate(cols_row,vals_row)
+      row_ptrs(irow+1)=row_ptrs(irow)+nnz
+    enddo
+
+    return
+  end subroutine Tpetra_CrsMatrix_getTestMatrixResults
+  ! ------------------------------- GetTestMatrixRow   ------------------------- !
+  ! Utility subroutine to handle the allocation logic for  creating the testMatrix
+  !   and the expect results:
+  ! Tpetra_CrsMatrix_CreateTestMatrix and  Tpetra_CrsMatrix_getTestMatrixResults
+  !
+  subroutine Tpetra_CrsMatrix_GetTestMatrixRow_A(comm, irow, gblrow, cols, vals, nnz)
+    type(TeuchosComm), intent(in) :: comm
+    integer, intent(in) :: irow
+    integer(global_ordinal_type), intent(out) :: gblrow
+    integer(global_ordinal_type), intent(out), allocatable :: cols(:)
+    real(scalar_type), intent(out), allocatable :: vals(:)
+    integer, intent(out) :: nnz
+    integer :: num_images, my_image_id
+
+    num_images = comm%getSize()
+    my_image_id = comm%getRank()
+
+    if (num_images < 2) then
+      gblrow = irow
+    else
+      gblrow = my_image_id*test_matrix_num_row() + irow
+    endif
+    if (gblrow == 1) then
+      nnz = 2
+      allocate(cols(nnz)); allocate(vals(nnz));
+      cols(1:nnz) = [gblrow, gblrow+1]
+      vals(1:nnz) = [2.d0, 1.d0]
+    else if (gblrow == num_images*test_matrix_num_row()) then
+      nnz = 2;
+      allocate(cols(nnz)); allocate(vals(nnz));
+      cols(1:nnz) = [gblrow-1, gblrow]
+      vals(1:nnz) = [1.d0, 2.d0]
+    else
+      nnz = 3;
+      allocate(cols(nnz)); allocate(vals(nnz));
+      cols = [gblrow-1, gblrow, gblrow+1]
+      vals = [1.d0, 1.d0, 1.d0]
+    end if
+
+    return
+  end subroutine Tpetra_CrsMatrix_GetTestMatrixRow_A
+  ! ------------------------------- Create Labelled Test Matrix ------------------------- !
+  !  do not call fillComplete
+  !  Create a matrix where things are globally labelled in a way to allow easy debugging
+  !  [2 3           ]
+  !  [  3 4         ]
+  !  [    4 5       ]
+  !  [      . . .   ]
+  !  [        . . . ]
+  subroutine Tpetra_CrsMatrix_CreateLabelledMat(comm,Mat)
+    type(TeuchosComm), intent(in) :: comm
+    type(TpetraCrsMatrix), intent(out) :: Mat
+    type(TpetraMap) :: rowMap
+    integer :: lclRow
+    integer :: numProcs
+    integer(global_ordinal_type) gblNumRows, gblNumCols, gblRow
+    integer(global_ordinal_type), allocatable :: gblColInds(:)
+    real(mag_type), allocatable :: vals(:)
+    integer(global_ordinal_type), allocatable :: curGblColInds(:)
+    real(mag_type), allocatable :: curVals(:)
+    integer(size_type), parameter :: ithree=3
+
+    ! create a Map
+    numProcs = comm%getSize()
+    gblNumRows = test_matrix_num_local() * numProcs
+    rowMap = TpetraMap(gblNumRows, test_matrix_num_local(), comm)
+
+    ! Leave room for three locally owned entries per row.
+    ! We will only fill in two entries per row.
+    Mat = TpetraCrsMatrix(rowMap, ithree, TpetraStaticProfile)
+    gblNumCols = gblNumRows
+
+    allocate(gblColInds(2),vals(2))
+
+    do lclRow = 1, test_matrix_num_local()
+      gblRow = rowMap%getGlobalElement(lclRow)
+      gblColInds(1) = 1 + modulo(gblRow + 0, gblNumCols)
+      gblColInds(2) = 1 + modulo(gblRow + 1, gblNumCols)
+
+      vals(1) = gblColInds(1)
+      vals(2) = gblColInds(2)
+
+      call Mat%insertGlobalValues(gblRow, gblColInds, vals)
+    end do
+
+    call rowMap%release()
+    deallocate(gblColInds,vals)
+
+    return
+  end subroutine Tpetra_CrsMatrix_CreateLabelledMat
+
+end module test_tpetra_crsmatrix_helper

--- a/src/tpetra/test/test_tpetra_import_export.F90
+++ b/src/tpetra/test/test_tpetra_import_export.F90
@@ -9,27 +9,40 @@ program test_TpetraImportExport
   use, intrinsic :: iso_c_binding
   use forteuchos
   use fortpetra
+  use test_tpetra_import_export_helper
 
   implicit none
   type(TeuchosComm) :: comm
-  character(len=30), parameter :: FILENAME="test_tpetraimport_export.F90"
+  character(len=30), parameter :: FILENAME="test_tpetra_import_export.F90"
 
   SETUP_TEST()
 
 #ifdef HAVE_MPI
   comm = TeuchosComm(MPI_COMM_WORLD); FORTRILINOS_CHECK_IERR()
 #else
-  comm = TeuchosComm()
+  comm = TeuchosComm(); FORTRILINOS_CHECK_IERR()
 #endif
 
   ADD_SUBTEST_AND_RUN(TpetraImportExport_Basic)
   ADD_SUBTEST_AND_RUN(TpetraImportExport_GetNeighborsForward)
-  !ADD_SUBTEST_AND_RUN(TpetraImportExport_AbsMax)
+  ADD_SUBTEST_AND_RUN(TpetraImportExport_AbsMax)
 
+  ADD_SUBTEST_AND_RUN(TpetraImportExport_getNumSameIDs)
+  ADD_SUBTEST_AND_RUN(TpetraImportExport_getNumRemoteIDs)
+  ADD_SUBTEST_AND_RUN(TpetraImportExport_getNumPermuteIDs)
+  ADD_SUBTEST_AND_RUN(TpetraImportExport_getNumExportIDs)
+  ADD_SUBTEST_AND_RUN(TpetraImportExport_getSourceMap)
+  ADD_SUBTEST_AND_RUN(TpetraImportExport_getTargetMap)
+
+  ! Methods will not work with 1 rank so skip
+  if(comm%getSize() /= 1) then
+    ADD_SUBTEST_AND_RUN(TpetraImport_createRemoteOnlyImport)
+  end if
+
+  ! Obsolete test
   !ADD_SUBTEST_AND_RUN(TpetraImport_isLocallyComplete)
-  !ADD_SUBTEST_AND_RUN(TpetraImport_createRemoteOnlyImport)
 
-  call comm%release()
+  call comm%release();   TEST_IERR()
 
   TEARDOWN_TEST()
 
@@ -37,18 +50,20 @@ contains
 
   ! -----------------------------------Basic --------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraImportExport_Basic)
-    type(TpetraMap) :: src, tgt
+    type(TpetraMap) :: tgt
     type(TpetraImport) :: importer
+    type(TpetraExport) :: exporter
     integer(size_type) :: same, permute, remote, expected_sum, the_sum
+    integer :: num_images
 
     OUT0("Starting TpetraImportExport_Basic!")
 
-    ! create Maps
-    src = TpetraMap(TPETRA_GLOBAL_INVALID, 10, comm)
-    tgt = TpetraMap(TPETRA_GLOBAL_INVALID, 5, comm)
+    num_images = comm%getSize()
 
     ! create Import object
-    importer = TpetraImport(src, tgt)
+    call Tpetra_IE_MakeImport(comm, 10 * num_images, 5 * num_images, importer)
+
+    tgt = importer%getTargetMap()
 
     same = importer%getNumSameIDs()
     permute = importer%getNumPermuteIDs()
@@ -57,6 +72,23 @@ contains
     expected_sum = tgt%getNodeNumElements()
     TEST_EQUALITY(the_sum, expected_sum)
 
+    ! Create Export and perform similar examination
+    call tgt%release(); TEST_IERR()
+    call Tpetra_IE_MakeExport(comm, 10 * num_images, 5 * num_images, exporter)
+
+    tgt = exporter%getTargetMap()
+
+    same = exporter%getNumSameIDs()
+    permute = exporter%getNumPermuteIDs()
+    remote = exporter%getNumRemoteIDs()
+    the_sum = same + permute + remote
+    expected_sum = tgt%getNodeNumElements()
+    TEST_EQUALITY(the_sum, expected_sum)
+
+    call tgt%release(); TEST_IERR()
+    call importer%release(); TEST_IERR()
+    call exporter%release(); TEST_IERR()
+
     OUT0("Finished TpetraImportExport_Basic!")
 
   END_FORTRILINOS_UNIT_TEST(TpetraImportExport_Basic)
@@ -64,7 +96,7 @@ contains
   ! ----------------------------- GetNeighborsForward ------------------------ !
 
   FORTRILINOS_UNIT_TEST(TpetraImportExport_GetNeighborsForward)
-    type(TpetraMap) :: src, tgt
+    type(TpetraMap) :: src, tgt, tmp
     type(TpetraImport) :: importer
     type(TpetraExport) :: exporter
     type(TpetraMultiVector) :: mv_mine, mv_with_neighbors
@@ -79,7 +111,7 @@ contains
     OUT0("Starting TpetraImportExport_GetNeighborsForward!")
 
     ! import with the importer to duplicate
-    ! export with the exporter to add and reduce
+     ! export with the exporter to add and reduce
     num_images = comm%getSize()
     my_image_id = comm%getRank()
 
@@ -137,8 +169,12 @@ contains
       exporter = TpetraExport(tgt, src)
 
       ! importer testing
-      TEST_ASSERT((src%isSameAs(importer%getSourceMap())))
-      TEST_ASSERT((tgt%isSameAs(importer%getTargetMap())))
+      tmp = importer%getSourceMap()
+      TEST_ASSERT(src%isSameAs(tmp))
+      call tmp%release();   TEST_IERR()
+      tmp = importer%getTargetMap()
+      TEST_ASSERT(tgt%isSameAs(tmp))
+      call tmp%release();   TEST_IERR()
 
       n = merge(1, 0, my_image_id == 0)
       TEST_EQUALITY(importer%getNumSameIDs(), n)
@@ -151,11 +187,15 @@ contains
       TEST_EQUALITY(importer%getNumRemoteIDs(), n)
 
       ! exporter testing
-      TEST_ASSERT(tgt%isSameAs(exporter%getSourceMap()))
-      TEST_ASSERT(src%isSameAs(exporter%getTargetMap()))
+      tmp = exporter%getSourceMap()
+      TEST_ASSERT(tgt%isSameAs(tmp))
+      call tmp%release();   TEST_IERR()
+      tmp = exporter%getTargetMap()
+      TEST_ASSERT(src%isSameAs(tmp))
+      call tmp%release();   TEST_IERR()
 
       n = merge(1, 0, my_image_id == 0)
-      TEST_EQUALITY(importer%getNumSameIDs(), n)
+      TEST_EQUALITY(exporter%getNumSameIDs(), n)
 
       n = merge(0, 1, my_image_id == 0)
       TEST_EQUALITY(exporter%getNumPermuteIDs(), n)
@@ -196,34 +236,33 @@ contains
         TEST_FLOATING_EQUALITY(a(1), val(1), epsilon(val(1)))
       end do
 
-      call mv_mine%release()
-      call mv_with_neighbors%release()
-      call mine_parent%release()
-      call neigh_parent%release()
-      call importer%release()
-      call exporter%release()
+      call mv_mine%release();   TEST_IERR()
+      call mv_with_neighbors%release();   TEST_IERR()
+      call mine_parent%release();   TEST_IERR()
+      call neigh_parent%release();   TEST_IERR()
+      call importer%release();   TEST_IERR()
+      call exporter%release();   TEST_IERR()
 
     end do
 
     deallocate(neighbors, val)
-    call src%release()
-    call tgt%release()
+    call src%release();   TEST_IERR()
+    call tgt%release();   TEST_IERR()
 
     OUT0("Finished TpetraImportExport_GetNeighborsForward!")
 
   END_FORTRILINOS_UNIT_TEST(TpetraImportExport_GetNeighborsForward)
 
-#if 0
   ! --------------------------------- AbsMax --------------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraImportExport_AbsMax)
     type(TpetraMap) :: smap, dmap
     type(TpetraImport) :: importer
-    type(TpetraExport) :: exporter
     type(TpetraMultiVector) :: svec, dvec
     integer(size_type) :: num_images
     real(scalar_type), pointer :: a(:)
-    integer :: lclrow
-    integer(global_ordinal_type) :: my_only_gid, cols(2)
+    integer :: k
+    integer(global_ordinal_type) :: num_global
+    integer(global_ordinal_type), allocatable :: cols(:)
     integer(size_type), parameter :: one=1
     integer(global_ordinal_type), parameter :: twog=2
 
@@ -235,75 +274,389 @@ contains
     num_images = comm%getSize()
 
     if (num_images < 2) return;
+    allocate(cols(2))
+    num_global = int(twog * num_images, kind = global_ordinal_type)
 
     ! create a Map
-    smap = TpetraMap(TPETRA_GLOBAL_INVALID, one, comm)
+    smap = TpetraMap(TPETRA_GLOBAL_INVALID, 1, comm)
 
-    lclrow = 1
-    my_only_gid = smap%getGlobalElement(lclrow)
-    cols(1) = my_only_gid
-    cols(2) = mod(my_only_gid+1, num_images)
-    dmap = TpetraMap(twog, cols, comm)
+    !Use noncontiguous map setup from isContiguous() in test_tpetra_map
+    do k = 1, 2
+        cols(k) = int(comm%getRank()+k*comm%getSize(), kind=global_ordinal_type)
+    end do
+
+    !Offset by 1 to make second element of dvec remote w.r.t svec
+    cols(1) = int(comm%getRank()+1, kind=global_ordinal_type)
+    dmap = TpetraMap(TPETRA_GLOBAL_INVALID, cols, comm)
 
     svec = TpetraMultiVector(smap, one)
     call svec%putScalar(-1.0_scalar_type)
 
     dvec = TpetraMultiVector(dmap, one)
-    call dvec%putScalar(-3.0_scalar_type)
+    call dvec%putScalar(3.0_scalar_type)
 
-    ! first item of dvec is local (w.r.t. srcVec), while the second is remote
+    ! first item of dvec is local (w.r.t. svec), while the second is remote
     ! ergo, during the import:
-    ! - the first will be over-written (by 1.0) from the source, while
-    ! - the second will be "combined", i.e., abs(max(1.0,3.0)) = 3.0 from the dest
+    ! - the first will be over-written (by -1.0) from the source, while
+    ! - the second will be "combined", i.e., abs(max(-1.0,3.0)) = 3.0 from the dest
     importer = TpetraImport(smap, dmap)
     call dvec%doImport(svec, importer, TpetraABSMAX)
 
     a => dvec%get1dView()
     TEST_FLOATING_EQUALITY(a(1), -1.0_scalar_type, epsilon(a(1)))
-    TEST_FLOATING_EQUALITY(a(2), 3.0_scalar_type, epsilon(a(1)))
+    TEST_FLOATING_EQUALITY(a(2), 3.0_scalar_type, epsilon(a(2)))
+
+    deallocate(cols)
+    call importer%release(); TEST_IERR()
+    call svec%release(); TEST_IERR()
+    call dvec%release(); TEST_IERR()
+    call smap%release(); TEST_IERR()
+    call dmap%release(); TEST_IERR()
 
     OUT0("Finished TpetraImportExport_AbsMax!")
 
   END_FORTRILINOS_UNIT_TEST(TpetraImportExport_AbsMax)
 
+ ! ------------------------------getNumSameIDs------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraImportExport_getNumSameIDs)
+    type(TpetraImport) :: imp
+    type(TpetraExport) :: exp
+    type(TpetraMap) :: tgt
+    integer :: numSame, numRemote, numPermute, numNodes
+    OUT0("Starting TpetraImportExport_getNumSameIDs!")
+
+    ! Use property that numSame + numRemote + numPermute = # elements on target map
+
+    ! Import test
+    call Tpetra_IE_MakeImport(comm, 5 * comm%getSize(), 2 * comm%getSize(), imp)
+    tgt = imp%getTargetMap()
+    numSame = imp%getNumSameIDs()
+    numRemote = imp%getNumRemoteIDs()
+    numPermute = imp%getNumPermuteIDs()
+    numNodes = tgt%getNodeNumElements()
+    TEST_EQUALITY(numSame, numNodes - numPermute - numRemote)
+
+    ! Export test
+    call tgt%release(); TEST_IERR()
+    call Tpetra_IE_MakeExport(comm, 5 * comm%getSize(), 2 * comm%getSize(), exp)
+    tgt = exp%getTargetMap()
+    numSame = exp%getNumSameIDs()
+    numRemote =	exp%getNumRemoteIDs()
+    numPermute = exp%getNumPermuteIDs()
+    numNodes = tgt%getNodeNumElements()
+    TEST_EQUALITY(numSame, numNodes - numPermute - numRemote)
+
+    call imp%release(); TEST_IERR()
+    call exp%release(); TEST_IERR()
+    call tgt%release(); TEST_IERR()
+
+    OUT0("Finished TpetraImportExport_getNumSameIDs!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraImportExport_getNumSameIDs)
+
+ ! ------------------------------getNumRemoteIDs------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraImportExport_getNumRemoteIDs)
+    type(TpetraImport) :: imp
+    type(TpetraExport) :: exp
+    type(TpetraMap) :: tgt
+    integer :: numSame, numRemote, numPermute, numNodes
+    OUT0("Starting TpetraImportExport_getNumRemoteIDs!")
+
+    ! Use property that numSame + numRemote + numPermute = # elements on target map
+
+    ! Import test
+    call Tpetra_IE_MakeImport(comm, 5 * comm%getSize(), 2 * comm%getSize(), imp)
+    tgt = imp%getTargetMap()
+    numSame = imp%getNumSameIDs()
+    numRemote = imp%getNumRemoteIDs()
+    numPermute = imp%getNumPermuteIDs()
+    numNodes = tgt%getNodeNumElements()
+    TEST_EQUALITY(numRemote, numNodes - numPermute - numSame)
+
+    ! Export test
+    call Tpetra_IE_MakeExport(comm, 5 * comm%getSize(), 2 * comm%getSize(), exp)
+    call tgt%release(); TEST_IERR()
+    numSame = exp%getNumSameIDs()
+    numRemote = exp%getNumRemoteIDs()
+    numPermute = exp%getNumPermuteIDs()
+    tgt = exp%getTargetMap()
+    numNodes = tgt%getNodeNumElements()
+    TEST_EQUALITY(numRemote, numNodes - numPermute - numSame)
+
+    call imp%release(); TEST_IERR()
+    call exp%release(); TEST_IERR()
+    call tgt%release(); TEST_IERR()
+
+    OUT0("Finished TpetraImportExport_getNumRemoteIDs!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraImportExport_getNumRemoteIDs)
+
+ ! ------------------------------getNumPermuteIDs------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraImportExport_getNumPermuteIDs)
+    type(TpetraImport) :: imp
+    type(TpetraExport) :: exp
+    type(TpetraMap) :: tgt
+    integer :: numSame, numRemote, numPermute, numNodes
+    OUT0("Starting TpetraImportExport_getNumPermuteIDs!")
+
+    ! Use property that numSame + numRemote + numPermute = # elements on target map
+
+    ! Import test
+    call Tpetra_IE_MakeImport(comm, 5 * comm%getSize(), 2 * comm%getSize(), imp)
+    tgt = imp%getTargetMap()
+    numSame = imp%getNumSameIDs()
+    numRemote = imp%getNumRemoteIDs()
+    numPermute = imp%getNumPermuteIDs()
+    numNodes = tgt%getNodeNumElements()
+    TEST_EQUALITY(numPermute, numNodes - numSame - numRemote)
+
+    ! Export test
+    call tgt%release(); TEST_IERR()
+    call Tpetra_IE_MakeExport(comm, 5 * comm%getSize(), 2 * comm%getSize(), exp)
+    numSame = exp%getNumSameIDs()
+    numRemote = exp%getNumRemoteIDs()
+    numPermute = exp%getNumPermuteIDs()
+    tgt = exp%getTargetMap()
+    numNodes = tgt%getNodeNumElements()
+    TEST_EQUALITY(numPermute, numNodes - numSame - numRemote)
+
+    call imp%release(); TEST_IERR()
+    call exp%release(); TEST_IERR()
+    call tgt%release(); TEST_IERR()
+
+    OUT0("Finished TpetraImportExport_getNumPermuteIDs!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraImportExport_getNumPermuteIDs)
+
+ ! ------------------------------getNumExportIDs------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraImportExport_getNumExportIDs)
+    type(TpetraImport) :: imp
+    type(TpetraExport) :: exp
+    type(TpetraMap) :: tgt
+    integer(size_type), allocatable :: n(:)
+    integer :: my_image_id, num_images, tmp, cond
+    OUT0("Starting TpetraImportExport_getNumExportIDs!")
+
+    my_image_id = comm%getRank()
+    num_images = comm%getSize()
+
+    if (num_images < 2) return;
+
+    ! Code here lifted from previous test
+    if (my_image_id == 0 .or. my_image_id == num_images-1) then
+      allocate(n(2))
+    else
+      allocate(n(3))
+    end if
+
+    if (my_image_id == 0) then
+      n(:) = [my_image_id+1, my_image_id+2]
+    else if (my_image_id == num_images - 1) then
+      n(:) = [my_image_id, my_image_id+1]
+    else
+      n(:) = [my_image_id, my_image_id+1, my_image_id+2]
+    end if
+
+    cond = merge(1, 2, (my_image_id == 0 .or. my_image_id == num_images-1))
+
+    ! Import test
+    call TPetra_IE_MakeImport_NU(comm, 1, n, imp)
+    tmp = imp%getNumExportIDs()
+    TEST_ASSERT(tmp == cond)
+
+    ! Export test
+    call TPetra_IE_MakeExport_NU(comm, n, 1, exp)
+    tmp = exp%getNumExportIDs()
+    TEST_ASSERT(tmp == cond)
+
+    deallocate(n)
+    call imp%release(); TEST_IERR()
+    call exp%release(); TEST_IERR()
+    call tgt%release(); TEST_IERR()
+
+    OUT0("Finished TpetraImportExport_getNumExportIDs!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraImportExport_getNumExportIDs)
+
+ ! ------------------------------getSourceMap------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraImportExport_getSourceMap)
+    type(TpetraImport) :: imp
+    type(TpetraExport) :: exp
+    type(TpetraMap) :: src, comp
+
+    OUT0("Starting TpetraImportExport_getSourceMap!")
+
+    ! Make both maps contiguous and uniform (1-to-1 required for import and export)
+    src = TpetraMap(TPETRA_GLOBAL_INVALID, 1 * comm%getSize(), comm)
+
+    ! Import test
+    call TPetra_IE_MakeImport(comm, 1 * comm%getSize(), 5 * comm%getSize(), imp)
+    comp = imp%getSourceMap()
+    TEST_ASSERT(src%isSameAs(comp))
+
+    ! Export test
+    call comp%release(); TEST_IERR()
+    call TPetra_IE_MakeExport(comm, 1 * comm%getSize(), 5 * comm%getSize(), exp)
+    comp = exp%getSourceMap()
+    TEST_ASSERT(src%isSameAs(comp))
+
+    call comp%release(); TEST_IERR()
+    call src%release(); TEST_IERR()
+    call imp%release(); TEST_IERR()
+    call exp%release(); TEST_IERR()
+
+    OUT0("Finished TpetraImportExport_getSourceMap!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraImportExport_getSourceMap)
+
+ ! ------------------------------getTargetMap------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraImportExport_getTargetMap)
+    type(TpetraImport) :: imp
+    type(TpetraExport) :: exp
+    type(TpetraMap) :: tgt, comp
+
+    OUT0("Starting TpetraImportExport_getTargetMap!")
+
+    ! Make both maps contiguous and uniform (1-to-1 required for import and export)
+    tgt = TpetraMap(TPETRA_GLOBAL_INVALID, 5 * comm%getSize(), comm)
+
+    ! Import test
+    call TPetra_IE_MakeImport(comm, 1 * comm%getSize(), 5 * comm%getSize(), imp)
+    comp = imp%getTargetMap()
+    TEST_ASSERT(tgt%isSameAs(comp))
+
+    ! Export test
+    call comp%release(); TEST_IERR()
+    call TPetra_IE_MakeExport(comm, 1 * comm%getSize(), 5 * comm%getSize(), exp)
+    comp = exp%getTargetMap()
+    TEST_ASSERT(tgt%isSameAs(comp))
+
+    call comp%release(); TEST_IERR()
+    call tgt%release(); TEST_IERR()
+    call imp%release(); TEST_IERR()
+    call exp%release(); TEST_IERR()
+
+    OUT0("Finished TpetraImportExport_getTargetMap!")
+
+  END_FORTRILINOS_UNIT_TEST(TpetraImportExport_getTargetMap)
+
+#if 0
+  !Obsolete test
   ! ----------------------------isLocallyComplete----------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraImport_isLocallyComplete)
-    type(TpetraImport) :: Obj
+    type(TpetraImport) :: imp
+    type(TpetraMap) :: src, tgt
+    integer :: exps, i
+    integer, allocatable :: expPIDs(:)
     OUT0("Starting TpetraImport_isLocallyComplete!")
 
-    success = .false.
+    src = TpetraMap(TPETRA_GLOBAL_INVALID, 1, comm)
+    tgt = TpetraMap(TPETRA_GLOBAL_INVALID, 1, comm)
 
-    !Obj = TpetraImport(); TEST_IERR()
-    !fresult = Obj%isLocallyComplete(); TEST_IERR()
+    imp = TpetraImport(src, tgt); TEST_IERR()
+    exps = imp%getNumExportIDs(); TEST_IERR()
+    allocate(expPIDs(exps)))
+    expPIDs = imp%getExportPIDs(); TEST_IERR()
+    do i = 1, size(expPIDs)
+       TEST_ASSERT(expPIDs(i) /= -1)
+    end do
 
-    !call Obj%release(); TEST_IERR()
-
-    write(*,*) 'TpetraImport_isLocallyComplete: Test not yet implemented'
+    deallocate(expPIDs)
+    call imp%release();   TEST_IERR()
+    call src%release();   TEST_IERR()
+    call tgt%release();   TEST_IERR()
 
     OUT0("Finished TpetraImport_isLocallyComplete!")
 
   END_FORTRILINOS_UNIT_TEST(TpetraImport_isLocallyComplete)
+#endif
 
   ! --------------------------createRemoteOnlyImport-------------------------- !
   FORTRILINOS_UNIT_TEST(TpetraImport_createRemoteOnlyImport)
-    type(TpetraImport) :: Obj
-    type(TpetraMap) :: remotetarget
+    type(TpetraImport) :: importer, remote_only_importer
+    type(TpetraMap) :: smap, dmap, remote_only_dmap
+    integer(size_type) :: remote_id_count, expected_id_count
+    integer :: gid, insert_gid_index, s_count, d_count, num_procs
+    integer(global_ordinal_type), allocatable :: gids(:)
+
     OUT0("Starting TpetraImport_createRemoteOnlyImport!")
 
-    success = .false.
+    num_procs = comm%getSize()
 
-    !remotetarget = TpetraMap(); TEST_IERR()
-    !Obj = TpetraImport(); TEST_IERR()
-    !fresult = Obj%createRemoteOnlyImport(remotetarget); TEST_IERR()
+    ! only tests in parallel - note Trilinos test also skips testing
+    ! createRemoteOnlyImport is num_procs = 1.
+    ! it appeasrs getNumRemoteIDs() gives the wrong value for serial or MPI 1 rank
+    ! it should be 0 but will include dmap elements not in smap
+    if (num_procs == 1) then
+      OUT0("Should not be calling TpetraImport_createRemoteOnlyImport because there is only 1 rank.")
+      return
+    end if
 
-    !call remotetarget%release(); TEST_IERR()
-    !call Obj%release(); TEST_IERR()
+    ! Note test is setup to pass for any values here
+    s_count = 5
+    d_count = 10
 
-    write(*,*) 'TpetraImport_createRemoteOnlyImport: Test not yet implemented'
+    smap = TpetraMap(TPETRA_GLOBAL_INVALID, s_count, comm); TEST_IERR()
+    dmap = TpetraMap(TPETRA_GLOBAL_INVALID, d_count, comm); TEST_IERR()
+
+    ! For example, 4 ranke:
+    ! Rank    0       1       2       3
+    ! smap   1-5      6-10    11-15   16-20
+    ! dmap   1-10     11-20   21-30   31-40
+
+    ! Now we need a new map which contains only the remote entries
+    ! That means entries in dmap which are in smap but not local
+    !        6-10     11-20    none    none
+
+    importer = TpetraImport(smap, dmap); TEST_IERR()
+    remote_id_count = importer%getNumRemoteIDs()
+
+    ! Make the new map with the proper count
+    allocate(gids(remote_id_count))
+
+    ! This can be eeplaced with getRemoteLIDs or used to test getRemoteLIDs
+    ! We woulld set each line like this:
+    !  do k = 1, remote_id_count
+    !    gids(k) = dmap%getGlobalElement(importer%getRemoteLIDs()[k])
+    !  end do
+    ! Currently getRemoteLIDs is ignored due to +- 1 issues to resolved.
+
+    ! Manually determine expected_id_count to compare
+    ! Also fill gids
+    ! We only care about ids in both, so loop 1 to min of s_count, d_count * num_procs
+    ! So we say it's in the remote map if:
+    !       it's in both maps
+    !   and it's not local in the smap
+    !   and it's local in the dmap
+    expected_id_count = 0
+    do gid = 1, min(d_count, s_count) * num_procs
+      ! Check if gid is not local to our smap - below or above our min/max local range
+      if ((gid <= s_count * comm%getRank()) .or. (gid > s_count * comm%getRank() + s_count)) then
+         ! Check if it is local to our dmap
+         if ((gid > d_count * comm%getRank()) .and. (gid <= d_count * comm%getRank() + d_count)) then
+          gids(expected_id_count+1) = gid
+          expected_id_count = expected_id_count + 1
+        end if
+      end if
+    end do
+
+    ! Validate the total count was filled as expected
+    TEST_EQUALITY(remote_id_count, expected_id_count)
+
+    remote_only_dmap = TpetraMap(TPETRA_GLOBAL_INVALID, gids, comm); TEST_IERR()
+
+    remote_only_importer = importer%createRemoteOnlyImport(remote_only_dmap); TEST_IERR()
+
+    TEST_EQUALITY(remote_id_count, remote_only_importer%getNumRemoteIDs())
+
+    call importer%release();   TEST_IERR()
+    call remote_only_importer%release();   TEST_IERR()
+    call smap%release();   TEST_IERR()
+    call dmap%release();   TEST_IERR()
+    call remote_only_dmap%release();   TEST_IERR()
+    deallocate(gids)
 
     OUT0("Finished TpetraImport_createRemoteOnlyImport!")
 
   END_FORTRILINOS_UNIT_TEST(TpetraImport_createRemoteOnlyImport)
-#endif
-
 end program test_TpetraImportExport

--- a/src/tpetra/test/test_tpetra_import_export_helper.F90
+++ b/src/tpetra/test/test_tpetra_import_export_helper.F90
@@ -1,0 +1,82 @@
+#include "ForTrilinosTpetra_config.hpp"
+module test_Tpetra_import_export_helper
+  use iso_fortran_env
+  use, intrinsic :: iso_c_binding
+  use forteuchos
+  use fortpetra
+
+  implicit none
+
+contains
+  ! ----------------------- Create An Import ----------------------------- !
+  !   For uniform contiguous distribution
+  subroutine Tpetra_IE_MakeImport(comm, srcDist, tgtDist, imp)
+    type(TeuchosComm), intent(in) :: comm
+    integer, intent(in) :: srcDist, tgtDist
+    type(TpetraImport), intent(out) :: imp
+    type(TpetraMap) :: src, tgt
+
+    src = TpetraMap(TPETRA_GLOBAL_INVALID, srcDist, comm)
+    tgt = TpetraMap(TPETRA_GLOBAL_INVALID, tgtDist, comm)
+
+    imp = TpetraImport(src, tgt)
+
+    call src%release()
+    call tgt%release()
+    return
+  end subroutine Tpetra_IE_MakeImport
+
+  !  For uniform distribution to nonuniform
+  subroutine Tpetra_IE_MakeImport_NU(comm, srcDist, tgtDist, imp)
+    type(TeuchosComm), intent(in) :: comm
+    integer(size_type), intent(in) :: tgtDist(:)
+    integer :: srcDist
+    type(TpetraImport), intent(out) :: imp
+    type(TpetraMap) :: src, tgt
+
+    src = TpetraMap(TPETRA_GLOBAL_INVALID, srcDist, comm)
+    tgt = TpetraMap(TPETRA_GLOBAL_INVALID, tgtDist, comm)
+
+    imp = TpetraImport(src, tgt)
+
+    call src%release()
+    call tgt%release()
+    return
+  end subroutine Tpetra_IE_MakeImport_NU
+
+  ! ----------------------- Create An Export ----------------------------- !
+  !   For uniform contiguous distribution
+  subroutine Tpetra_IE_MakeExport(comm, srcDist, tgtDist, exp)
+    type(TeuchosComm), intent(in) :: comm
+    integer, intent(in) :: srcDist, tgtDist
+    type(TpetraExport), intent(out) :: exp
+    type(TpetraMap) :: src, tgt
+
+    src = TpetraMap(TPETRA_GLOBAL_INVALID, srcDist, comm)
+    tgt = TpetraMap(TPETRA_GLOBAL_INVALID, tgtDist, comm)
+
+    exp = TpetraExport(src, tgt)
+
+    call src%release()
+    call tgt%release()
+    return
+  end subroutine Tpetra_IE_MakeExport
+
+  !  For nonuniform distribution to uniform
+  subroutine Tpetra_IE_MakeExport_NU(comm, srcDist, tgtDist, exp)
+    type(TeuchosComm), intent(in) :: comm
+    integer(size_type), intent(in) :: srcDist(:)
+    integer :: tgtDist
+    type(TpetraExport), intent(out) :: exp
+    type(TpetraMap) :: src, tgt
+
+    src = TpetraMap(TPETRA_GLOBAL_INVALID, srcDist, comm)
+    tgt = TpetraMap(TPETRA_GLOBAL_INVALID, tgtDist, comm)
+
+    exp = TpetraExport(src, tgt)
+
+    call src%release()
+    call tgt%release()
+    return
+  end subroutine Tpetra_IE_MakeExport_NU
+end module test_Tpetra_import_export_helper

--- a/src/tpetra/test/test_tpetra_map.F90
+++ b/src/tpetra/test/test_tpetra_map.F90
@@ -44,12 +44,13 @@ program test_TpetraMap
   ADD_SUBTEST_AND_RUN(TpetraMap_locallySameAs)
   ADD_SUBTEST_AND_RUN(TpetraMap_getComm)
   ADD_SUBTEST_AND_RUN(TpetraMap_description)
+  ADD_SUBTEST_AND_RUN(TpetraMap_isLocallyFitted)
 
   ! Methods listed below are marked as "may go away or change at any time"
-  ADD_SUBTEST_AND_RUN(TpetraMap_removeEmptyProcesses)
-  ADD_SUBTEST_AND_RUN(TpetraMap_replaceCommWithSubset)
+  !ADD_SUBTEST_AND_RUN(TpetraMap_removeEmptyProcesses)
+  !ADD_SUBTEST_AND_RUN(TpetraMap_replaceCommWithSubset)
 
-  call comm%release()
+  call comm%release();  TEST_IERR()
 
   TEARDOWN_TEST()
 
@@ -418,18 +419,16 @@ contains
     call Obj%release(); TEST_IERR()
   END_FORTRILINOS_UNIT_TEST(TpetraMap_description)
 
-! ----------------------------removeEmptyProcesses---------------------------- !
-  FORTRILINOS_UNIT_TEST(TpetraMap_removeEmptyProcesses)
-    ! TODO: Implement this test?
-    if (comm%getRank()==0) &
-      write(*,*) 'removeEmptyProcesses: Test is not yet Implemented'
-  END_FORTRILINOS_UNIT_TEST(TpetraMap_removeEmptyProcesses)
-
-! ---------------------------replaceCommWithSubset---------------------------- !
-  FORTRILINOS_UNIT_TEST(TpetraMap_replaceCommWithSubset)
-    ! TODO: Implement this test?
-    if (comm%getRank()==0) &
-      write(*,*) 'replaceCommWithSubset: Test is not yet implemented'
-  END_FORTRILINOS_UNIT_TEST(TpetraMap_replaceCommWithSubset)
+! ------------------------------isLocallyFitted------------------------------- !
+  FORTRILINOS_UNIT_TEST(TpetraMap_isLocallyFitted)
+    type(TpetraMap) :: map1, map2
+    integer(global_ordinal_type) :: num_global
+    num_global = 4*comm%getSize()
+    map1 = TpetraMap(num_global, comm); TEST_IERR()
+    map2 = TpetraMap(num_global, comm); TEST_IERR()
+    TEST_ASSERT(map1%isLocallyFitted(map2))
+    call map1%release(); TEST_IERR()
+    call map2%release(); TEST_IERR()
+  END_FORTRILINOS_UNIT_TEST(TpetraMap_isLocallyFitted)
 
 end program test_TpetraMap

--- a/src/tpetra/test/test_tpetra_multivector.F90
+++ b/src/tpetra/test/test_tpetra_multivector.F90
@@ -660,7 +660,7 @@ contains
     integer, parameter :: num_local = 4
     integer(size_type), parameter :: num_vecs = 2
     integer(size_type) :: cols(1)
-    real(dp) :: resNorm(1), vecNorm(1), expect
+    real(dp) :: resNorm(1), vecNorm(num_vecs), expect
 
     OUT0("Starting TpetraMultiVector_subView!")
 
@@ -681,7 +681,8 @@ contains
 
     call res%putScalar(0.0_dp)
     call vec%norm1(vecNorm)
-    TEST_FLOATING_ARRAY_EQUALITY(vecNorm, 0.0_dp, epsilon(0.0_dp))
+    TEST_FLOATING_EQUALITY(vecNorm(1), 0.0_dp, epsilon(0.0_dp))
+    TEST_FLOATING_EQUALITY(vecNorm(2), expect, epsilon(0.0_dp))
 
     call vec%release(); TEST_IERR()
     call res%release(); TEST_IERR()
@@ -696,7 +697,7 @@ contains
     integer, parameter :: num_local = 4
     integer(size_type), parameter :: num_vecs = 2
     integer(size_type) :: cols(1)
-    real(dp) :: resNorm(1), vecNorm(1), expect
+    real(dp) :: resNorm(1), vecNorm(num_vecs), expect
 
     OUT0("Starting TpetraMultiVector_subViewNonConst!")
 
@@ -718,7 +719,8 @@ contains
 
     call res%putScalar(0.0_dp)
     call vec%norm1(vecNorm)
-    TEST_FLOATING_ARRAY_EQUALITY(vecNorm, 0.0_dp, epsilon(0.0_dp))
+    TEST_FLOATING_EQUALITY(vecNorm(1), 0.0_dp, epsilon(0.0_dp))
+    TEST_FLOATING_EQUALITY(vecNorm(2), expect, epsilon(0.0_dp))
 
     call vec%release(); TEST_IERR()
     call res%release(); TEST_IERR()

--- a/src/tpetra/test/test_tpetra_multivector.F90
+++ b/src/tpetra/test/test_tpetra_multivector.F90
@@ -1,7 +1,7 @@
 ! Copyright 2017-2018, UT-Battelle, LLC
 !
 ! SPDX-License-Identifier: BSD-3-Clause
-! License-Filename: LIeENSE
+! License-Filename: LICENSE
 program test_TpetraMultiVector
 #include "ForTrilinosTpetra_config.hpp"
 #include "FortranTestUtilities.h"

--- a/src/tpetra/test/test_tpetra_multivector_helper.F90
+++ b/src/tpetra/test/test_tpetra_multivector_helper.F90
@@ -1,0 +1,32 @@
+#include "ForTrilinosTpetra_config.hpp"
+module test_Tpetra_multivector_helper
+  use iso_fortran_env
+  use, intrinsic :: iso_c_binding
+  use forteuchos
+  use fortpetra
+
+  implicit none
+
+contains
+  ! ----------------------- Create A Vector ----------------------------- !
+  !   For uniform contiguous distribution
+  subroutine Tpetra_MV_Create(comm, num_local, num_vecs, vec, init_val)
+    integer, parameter :: dp = kind(0.d0)
+    type(TeuchosComm), intent(in) :: comm
+    integer, intent(in) :: num_local
+    integer(size_type) :: num_vecs
+    type(TpetraMultiVector), intent(out) :: vec
+    type(TpetraMap) :: src
+    real(dp), intent(in), optional :: init_val
+
+    src = TpetraMap(TPETRA_GLOBAL_INVALID, num_local, comm)
+    vec = TpetraMultiVector(src, num_vecs)
+    if (present(init_val)) then
+       call vec%putScalar(init_val)
+
+    end if
+
+    call src%release()
+  end subroutine Tpetra_MV_Create
+
+end module test_Tpetra_multivector_helper

--- a/src/tpetra/test/test_tpetra_multivector_helper.F90
+++ b/src/tpetra/test/test_tpetra_multivector_helper.F90
@@ -27,7 +27,6 @@ contains
     end if
 
     call src%release()
-    write(*,*) vec%swigdata%cmemflags
   end subroutine Tpetra_MV_Create
 
 end module test_Tpetra_multivector_helper

--- a/src/tpetra/test/test_tpetra_multivector_helper.F90
+++ b/src/tpetra/test/test_tpetra_multivector_helper.F90
@@ -27,6 +27,7 @@ contains
     end if
 
     call src%release()
+    write(*,*) vec%swigdata%cmemflags
   end subroutine Tpetra_MV_Create
 
 end module test_Tpetra_multivector_helper


### PR DESCRIPTION
This goes through and increases coverage in CrsGraph and CrsMatrix.
Many of the methods are just testing that they run and not that they run
correctly because they use this idiom:
    fresult = graph%getFoo(); TEST_IERR()
This probably needs improving.

gaussSeidel is an example of a test that needs further work.

Also, the skeleton for these tests was done awhile ago and the API has
changed.  Coverage tests should be used to see what is missing once the
nightlies come through.