### PR TITLE
Replace ForTrilinosVersion with CgvFindVersion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,8 @@
 cmake_minimum_required(VERSION 3.12)
 
 # Determine version number from git metadata
-include("${CMAKE_CURRENT_LIST_DIR}/cmake/ForTrilinosVersion.cmake")
-fortrilinos_find_version(ForTrilinos
-  "${CMAKE_CURRENT_LIST_DIR}/cmake/git-version.txt"
-)
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/CgvFindVersion.cmake")
+cgv_find_version(ForTrilinos)
 
 project(ForTrilinos VERSION "${ForTrilinos_VERSION}" LANGUAGES CXX Fortran)
 cmake_policy(VERSION 3.12...3.18)

--- a/cmake/.gitattributes
+++ b/cmake/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes export-ignore
+/CgvFindVersion.cmake export-subst

--- a/cmake/git-version.txt
+++ b/cmake/git-version.txt
@@ -1,2 +1,0 @@
-$Format:%D$
-$Format:%h$ 


### PR DESCRIPTION
Consolidate the cmake/git version coupling into a single cmake helper script, the gold copy of which now lives at https://github.com/sethrj/cmake-git-version .